### PR TITLE
Removing redundant params from pbmm2

### DIFF
--- a/workflows/smrtcell_analysis/smrtcell_analysis.wdl
+++ b/workflows/smrtcell_analysis/smrtcell_analysis.wdl
@@ -96,8 +96,6 @@ task pbmm2_align {
 			--log-level INFO \
 			--sort \
 			--unmapped \
-			-c 0 \
-			-y 70 \
 			~{reference} \
 			~{bam} \
 			~{sample_id}.~{movie}.~{reference_name}.aligned.bam


### PR DESCRIPTION
In recent versions of pbmm2, `-c 0 -y 70` are part of `--preset CCS`.