### PR TITLE
Add pbsv VCF index to inputs for svpack

### DIFF
--- a/workflows/tertiary_analysis/tertiary_analysis.wdl
+++ b/workflows/tertiary_analysis/tertiary_analysis.wdl
@@ -98,6 +98,7 @@ workflow tertiary_analysis {
 	call svpack_filter_annotated {
 		input:
 			sv_vcf = sv_vcf.data,
+			sv_vcf_index = sv_vcf.data_index,
 			population_vcfs = population_vcf,
 			population_vcf_indices = population_vcf_index,
 			gff = reference.gff,
@@ -535,6 +536,7 @@ task slivar_tsv {
 task svpack_filter_annotated {
 	input {
 		File sv_vcf
+		File sv_vcf_index
 
 		Array[File] population_vcfs
 		Array[File] population_vcf_indices


### PR DESCRIPTION
svpack shouldn't _need_ indexes, but is it possible that the missing index is the cause of the issue (`[E::idx_find_and_load]`)?  We didn't have the index listed as an explicit input in the snakemake workflow, but it was always available.

The index is generated already, and it's small, so is it worth testing?