### PR TITLE
Prune redudant outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,6 @@ These files will be output for each sample defined in the cohort.
 | Array[Array[File]] | bam_stats | Statistics for the set of movie bams for each sample | |
 | Array[Array[File]] | read_length_summary | Read length stats for the set of movie bams for each sample | |
 | Array[Array[File]] | read_length_quality_summary | Read length quality summaries for the set of movie bams for each sample | |
-| Array[Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)]] | aligned_bams | Set of aligned bams for the set of movie bams for each sample | |
-| Array[Array[File]] | aligned_bam_mosdepth_summary | Mosdepth summary for the set of aligned bams for each sample | |
-| Array[Array[File]] | aligned_bam_mosdepth_region_bed | Mosdepth region bed for the set of aligned bams for each sample | |
-| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | small_variant_vcfs | | |
 | Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | small_variant_gvcfs | | |
 | Array[File] | small_variant_vcf_stats | | |
 | Array[File] | small_variant_roh_bed | | |

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -110,12 +110,8 @@ workflow humanwgs {
 		Array[Array[File]] bam_stats = sample_analysis.bam_stats
 		Array[Array[File]] read_length_summary = sample_analysis.read_length_summary
 		Array[Array[File]] read_quality_summary = sample_analysis.read_quality_summary
-		Array[Array[IndexData]] aligned_bams = sample_analysis.aligned_bams
-		Array[Array[File]] aligned_bam_mosdepth_summary = sample_analysis.aligned_bam_mosdepth_summary
-		Array[Array[File]] aligned_bam_mosdepth_region_bed = sample_analysis.aligned_bam_mosdepth_region_bed
 
 		# sample_analysis output
-		Array[IndexData] small_variant_vcfs = sample_analysis.small_variant_vcf
 		Array[IndexData] small_variant_gvcfs = sample_analysis.small_variant_gvcf
 		Array[File] small_variant_vcf_stats = sample_analysis.small_variant_vcf_stats
 		Array[File] small_variant_roh_bed = sample_analysis.small_variant_roh_bed

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -136,8 +136,6 @@ workflow sample_analysis {
 		Array[File] read_length_summary = smrtcell_analysis.read_length_summary
 		Array[File] read_quality_summary = smrtcell_analysis.read_quality_summary
 		Array[IndexData] aligned_bams = smrtcell_analysis.aligned_bams
-		Array[File] aligned_bam_mosdepth_summary = smrtcell_analysis.aligned_bam_mosdepth_summary
-		Array[File] aligned_bam_mosdepth_region_bed = smrtcell_analysis.aligned_bam_mosdepth_region_bed
 		Array[File] svsigs = smrtcell_analysis.svsigs
 
 		IndexData small_variant_vcf = deepvariant.vcf

--- a/workflows/smrtcell_analysis/smrtcell_analysis.wdl
+++ b/workflows/smrtcell_analysis/smrtcell_analysis.wdl
@@ -3,7 +3,6 @@ version 1.0
 # Align reads to a reference genome and generates statistic on alignment depth, read length, and alignment quality.
 
 import "../humanwgs_structs.wdl"
-import "../wdl-common/wdl/tasks/mosdepth.wdl" as Mosdepth
 import "../wdl-common/wdl/tasks/pbsv_discover.wdl" as PbsvDiscover
 
 workflow smrtcell_analysis {
@@ -26,13 +25,6 @@ workflow smrtcell_analysis {
 				runtime_attributes = default_runtime_attributes
 		}
 
-		call Mosdepth.mosdepth {
-			input:
-				aligned_bam = pbmm2_align.aligned_bam,
-				aligned_bam_index = pbmm2_align.aligned_bam_index,
-				runtime_attributes = default_runtime_attributes
-		}
-
 		call PbsvDiscover.pbsv_discover {
 			input:
 				aligned_bam = pbmm2_align.aligned_bam,
@@ -52,8 +44,6 @@ workflow smrtcell_analysis {
 		Array[File] read_length_summary = pbmm2_align.read_length_summary
 		Array[File] read_quality_summary = pbmm2_align.read_quality_summary
 		Array[IndexData] aligned_bams = aligned_bam
-		Array[File] aligned_bam_mosdepth_summary = mosdepth.summary
-		Array[File] aligned_bam_mosdepth_region_bed = mosdepth.region_bed
 		Array[File] svsigs = pbsv_discover.svsig
 	}
 


### PR DESCRIPTION
As I was updating the documentation (PR to follow), noticed some redundant output and tried to remove it cleanly.

- removed per-movie mosdepth tasks and outputs (not exactly redundant, but unnecessary in this context)
- removed per-movie alignments from `main.humanwgs.output` (redundant with merged, haplotagged alignments)
- removed DeepVariant output small variant vcf (redundant with DeepVariant+WhatsHap phased small variant vcf) from `main.humanwgs.output`