### PR TITLE
Parallelize pbsv call

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -393,36 +393,6 @@
         }
       }
     },
-    "workflows/wdl-common/wdl/tasks/zip_index_vcf.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/zip_index_vcf.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "zip_index_vcf": {
-          "key": "zip_index_vcf",
-          "digest": "cflenxzb6uj2ujfv4pkllo3vztdkev45",
-          "tests": [
-            {
-              "inputs": {
-                "vcf": "${resources_file_path}/HG005.GRCh38.pbsv.vcf",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "zipped_vcf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
     "workflows/wdl-common/wdl/tasks/glnexus.wdl": {
       "key": "workflows/wdl-common/wdl/tasks/glnexus.wdl",
       "name": "",
@@ -488,10 +458,48 @@
               },
               "output_tests": {
                 "pbsv_vcf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.pbsv.vcf",
+                  "value": "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz",
                   "test_tasks": [
                     "compare_file_basename",
-                    "vcftools_validator"
+                    "vcftools_validator",
+                    "check_gzip"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "workflows/wdl-common/wdl/tasks/concat_vcf.wdl": {
+      "key": "workflows/wdl-common/wdl/tasks/concat_vcf.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "concat_vcf": {
+          "key": "concat_vcf",
+          "digest": "",
+          "tests": [
+            {
+              "inputs": {
+                "vcfs": [
+                  "${resources_file_path}/HG005.GRCh38.chr5.pbsv.vcf.gz",
+                  "${resources_file_path}/HG005.GRCh38.chr6.pbsv.vcf.gz"
+                ],
+                "vcf_indices": [
+                  "${resources_file_path}/HG005.GRCh38.chr5.pbsv.vcf.gz.tbi",
+                  "${resources_file_path}/HG005.GRCh38.chr6.pbsv.vcf.gz.tbi"
+                ],
+                "output_vcf_name": "HG005.GRCh38.chr5chr6.pbsv.vcf.gz",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "concatenated_vcf": {
+                  "value": "${resources_file_path}/HG005.GRCh38.chr5chr6.pbsv.vcf.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "vcftools_validator",
+                    "check_gzip"
                   ]
                 }
               }

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -481,6 +481,7 @@
                 "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
                 "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
                 "reference_name": "GRCh38",
+                "regions": [ "chr6" ],
                 "runtime_attributes": "${default_runtime_attributes}"
               },
               "output_tests": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -470,7 +470,7 @@
       "tasks": {
         "pbsv_call": {
           "key": "pbsv_call",
-          "digest": "ptzjrqbvzgvdhb52u3qrlr4iclxvktg5",
+          "digest": "fnnqhxt6mj443vwr6jydkzbnwxdxmnyt",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -79,7 +79,7 @@
         },
         "bcftools_roh": {
           "key": "bcftools_roh",
-          "digest": "cdlg76jdsf6cvxr72yswncp57qrweu6c",
+          "digest": "wyp43tacw5ovlm24ypisltgmgilpudcp",
           "tests": [
             {
               "inputs": {
@@ -369,7 +369,7 @@
       "tasks": {
         "pbsv_discover": {
           "key": "pbsv_discover",
-          "digest": "uqkzepaarj4mxxlx2ly6kjqpezztbarh",
+          "digest": "lbv7nwockw3wcbkfvapzoc2wv7fcodnw",
           "tests": [
             {
               "inputs": {
@@ -481,7 +481,9 @@
                 "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
                 "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
                 "reference_name": "GRCh38",
-                "regions": [ "chr6" ],
+                "regions": [
+                  "chr6"
+                ],
                 "runtime_attributes": "${default_runtime_attributes}"
               },
               "output_tests": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -440,7 +440,7 @@
       "tasks": {
         "pbsv_call": {
           "key": "pbsv_call",
-          "digest": "74dzkdthagrt7twghinxtwqe6myrmtuc",
+          "digest": "77yon47d6t327ocrw6bed3dccyq5t3va",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -440,7 +440,7 @@
       "tasks": {
         "pbsv_call": {
           "key": "pbsv_call",
-          "digest": "fnnqhxt6mj443vwr6jydkzbnwxdxmnyt",
+          "digest": "74dzkdthagrt7twghinxtwqe6myrmtuc",
           "tests": [
             {
               "inputs": {
@@ -478,7 +478,7 @@
       "tasks": {
         "concat_vcf": {
           "key": "concat_vcf",
-          "digest": "",
+          "digest": "ntfiawmetxbdacle2l7mpu5tkz2jmtz2",
           "tests": [
             {
               "inputs": {

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -50,7 +50,7 @@ workflow cohort_analysis {
 
 	call ConcatVcf.concat_vcf {
 		input:
-			vcfs = flatten(pbsv_call.pbsv_vcf),
+			vcfs = pbsv_call.pbsv_vcf,
 			output_vcf_name = "~{cohort_id}.joint.~{reference.name}.pbsv.vcf",
 			runtime_attributes = default_runtime_attributes
 	}

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -5,7 +5,6 @@ version 1.0
 import "../humanwgs_structs.wdl"
 import "../wdl-common/wdl/tasks/pbsv_call.wdl" as PbsvCall
 import "../wdl-common/wdl/tasks/concat_vcf.wdl" as ConcatVcf
-import "../wdl-common/wdl/tasks/zip_index_vcf.wdl" as ZipIndexVcf
 import "../wdl-common/wdl/tasks/glnexus.wdl" as Glnexus
 import "../wdl-common/wdl/workflows/hiphase/hiphase.wdl" as HiPhase
 
@@ -51,19 +50,14 @@ workflow cohort_analysis {
 	call ConcatVcf.concat_vcf {
 		input:
 			vcfs = pbsv_call.pbsv_vcf,
-			output_vcf_name = "~{cohort_id}.joint.~{reference.name}.pbsv.vcf",
-			runtime_attributes = default_runtime_attributes
-	}
-
-	call ZipIndexVcf.zip_index_vcf {
-		input:
-			vcf = concat_vcf.concatenated_vcf,
+			vcf_indices = pbsv_call.pbsv_vcf_index,
+			output_vcf_name = "~{cohort_id}.joint.~{reference.name}.pbsv.vcf.gz",
 			runtime_attributes = default_runtime_attributes
 	}
 
 	IndexData zipped_pbsv_vcf = {
-		"data": zip_index_vcf.zipped_vcf,
-		"data_index": zip_index_vcf.zipped_vcf_index
+		"data": concat_vcf.concatenated_vcf,
+		"data_index": concat_vcf.concatenated_vcf_index
 	}
 
 	call Glnexus.glnexus {

--- a/workflows/humanwgs_structs.wdl
+++ b/workflows/humanwgs_structs.wdl
@@ -6,6 +6,8 @@ struct ReferenceData {
 	String name
 	IndexData fasta
 
+	File pbsv_splits
+
 	File tandem_repeat_bed
 	File trgt_tandem_repeat_bed
 

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -91,7 +91,7 @@ workflow sample_analysis {
 
 	call ConcatVcf.concat_vcf {
 		input:
-			vcfs = flatten(pbsv_call.pbsv_vcf),
+			vcfs = pbsv_call.pbsv_vcf,
 			output_vcf_name = "~{sample.sample_id}.~{reference.name}.pbsv.vcf",
 			runtime_attributes = default_runtime_attributes
 	}

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -9,7 +9,6 @@ import "../wdl-common/wdl/tasks/bcftools_stats.wdl" as BcftoolsStats
 import "../wdl-common/wdl/tasks/mosdepth.wdl" as Mosdepth
 import "../wdl-common/wdl/tasks/pbsv_call.wdl" as PbsvCall
 import "../wdl-common/wdl/tasks/concat_vcf.wdl" as ConcatVcf
-import "../wdl-common/wdl/tasks/zip_index_vcf.wdl" as ZipIndexVcf
 import "../wdl-common/wdl/workflows/hiphase/hiphase.wdl" as HiPhase
 
 workflow sample_analysis {
@@ -92,19 +91,14 @@ workflow sample_analysis {
 	call ConcatVcf.concat_vcf {
 		input:
 			vcfs = pbsv_call.pbsv_vcf,
-			output_vcf_name = "~{sample.sample_id}.~{reference.name}.pbsv.vcf",
-			runtime_attributes = default_runtime_attributes
-	}
-
-	call ZipIndexVcf.zip_index_vcf {
-		input:
-			vcf = concat_vcf.concatenated_vcf,
+			vcf_indices = pbsv_call.pbsv_vcf_index,
+			output_vcf_name = "~{sample.sample_id}.~{reference.name}.pbsv.vcf.gz",
 			runtime_attributes = default_runtime_attributes
 	}
 
 	IndexData zipped_pbsv_vcf = {
-		"data": zip_index_vcf.zipped_vcf,
-		"data_index": zip_index_vcf.zipped_vcf_index
+		"data": concat_vcf.concatenated_vcf,
+		"data_index": concat_vcf.concatenated_vcf_index
 	}
 
 	call HiPhase.hiphase {


### PR DESCRIPTION
Split `pbsv call` task into 14 sets of ~150-300Mbp, never splitting chromosomes.

- depends on changes to pbsv_call and the addition of concat_vcf in https://github.com/PacificBiosciences/wdl-common/pull/29
- depends on a new input, `"pbsv_splits": "dataset/GRCh38/human_GRCh38_no_alt_analysis_set.pbsv_splits.json"`, which is a json file with an `Array[Array[String]]`.  Each `Array[String]` is a set of chromosomes to be processed by the same task.