### PR TITLE
Fix for concat_vcf for miniwdl.  Link all inputs into a single directory so that vcfs and indices are together.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -419,7 +419,7 @@
       "tasks": {
         "pbsv_call": {
           "key": "pbsv_call",
-          "digest": "77yon47d6t327ocrw6bed3dccyq5t3va",
+          "digest": "o5xv2etbm2j4s32d5xs626xj6sp2ykmj",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -457,7 +457,7 @@
       "tasks": {
         "concat_vcf": {
           "key": "concat_vcf",
-          "digest": "ntfiawmetxbdacle2l7mpu5tkz2jmtz2",
+          "digest": "xkyvutmrg3gz6zgabdmwcjvcbwrbwwp7",
           "tests": [
             {
               "inputs": {

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -32,7 +32,9 @@ workflow cohort_analysis {
 		File gvcf_index = gvcf_object.data_index
 	}
 
-	scatter (region_set in pbsv_splits) {
+	scatter (shard_index in range(length(pbsv_splits))) {
+        Array[String] region_set = pbsv_splits[shard_index]
+
 		call PbsvCall.pbsv_call {
 			input:
 				sample_id = cohort_id + ".joint",
@@ -41,6 +43,7 @@ workflow cohort_analysis {
 				reference = reference.fasta.data,
 				reference_index = reference.fasta.data_index,
 				reference_name = reference.name,
+				shard_index = shard_index,
 				regions = region_set,
 				mem_gb = pbsv_call_mem_gb,
 				runtime_attributes = default_runtime_attributes

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -68,7 +68,9 @@ workflow sample_analysis {
 			runtime_attributes = default_runtime_attributes
 	}
 
-	scatter (region_set in pbsv_splits) {
+	scatter (shard_index in range(length(pbsv_splits))) {
+        Array[String] region_set = pbsv_splits[shard_index]
+
 		call PbsvCall.pbsv_call {
 			input:
 				sample_id = sample.sample_id,

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -78,6 +78,7 @@ workflow sample_analysis {
 				reference = reference.fasta.data,
 				reference_index = reference.fasta.data_index,
 				reference_name = reference.name,
+				shard_index = shard_index,
 				regions = region_set,
 				runtime_attributes = default_runtime_attributes
 		}


### PR DESCRIPTION
concat_vcf receives an array of vcf.gz and an array of vcf.gz.tbi. Cromwell groups each pair together in a separate inputs folder (because they were generated by the same upstream task), but miniwdl provides each input independently in its own directory, so the index isn't grouped with the VCF.  This PR links all inputs together into a single directory so bcftools can find the indices.