### PR TITLE
fix: Handle missing output for paraphase.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -245,7 +245,7 @@
         },
         "paraphase": {
           "key": "paraphase",
-          "digest": "p36f7pt2tghztqhtdgreyxohbjjndg3i",
+          "digest": "xme5pugrmhvnys5vas6jfagm65eac4hz",
           "tests": [
             {
               "inputs": {

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -130,7 +130,7 @@ workflow humanwgs {
 		# per sample paraphase outputs
 		Array[File] paraphase_output_jsons = sample_analysis.paraphase_output_json
 		Array[IndexData] paraphase_realigned_bams = sample_analysis.paraphase_realigned_bam
-		Array[File] paraphase_vcfs = sample_analysis.paraphase_vcfs
+		Array[File?] paraphase_vcfs = sample_analysis.paraphase_vcfs
 
 		# per sample hificnv outputs
 		Array[IndexData] hificnv_vcfs = sample_analysis.hificnv_vcf

--- a/workflows/sample_analysis/sample_analysis.wdl
+++ b/workflows/sample_analysis/sample_analysis.wdl
@@ -231,7 +231,7 @@ workflow sample_analysis {
 		# per sample paraphase outputs
 		File paraphase_output_json = paraphase.output_json
 		IndexData paraphase_realigned_bam = {"data": paraphase.realigned_bam, "data_index": paraphase.realigned_bam_index}
-		File paraphase_vcfs = paraphase.paraphase_vcfs
+		File? paraphase_vcfs = paraphase.paraphase_vcfs
 
 		# per sample hificnv outputs
 		IndexData hificnv_vcf = {"data": hificnv.cnv_vcf, "data_index": hificnv.cnv_vcf_index}
@@ -639,16 +639,18 @@ task paraphase {
 			--reference ~{reference} \
 			--out ~{out_directory}
 
-		cd ~{out_directory} \
-			&& tar zcvf ~{out_directory}.tar.gz ~{sample_id}_vcfs/*.vcf \
-			&& mv ~{out_directory}.tar.gz ../
+		if ls ~{out_directory}/~{sample_id}_vcfs/*.vcf &> /dev/null; then
+			cd ~{out_directory} \
+				&& tar zcvf ~{out_directory}.tar.gz ~{sample_id}_vcfs/*.vcf \
+				&& mv ~{out_directory}.tar.gz ../
+		fi
 	>>>
 
 	output {
 		File output_json = "~{out_directory}/~{sample_id}.json"
 		File realigned_bam = "~{out_directory}/~{sample_id}_realigned_tagged.bam"
 		File realigned_bam_index = "~{out_directory}/~{sample_id}_realigned_tagged.bam.bai"
-		File paraphase_vcfs = "~{out_directory}.tar.gz"
+		File? paraphase_vcfs = "~{out_directory}.tar.gz"
 	}
 
 	runtime {


### PR DESCRIPTION
If the input BAM doesn't cover any of the paraphase regions, there are no VCFs to tar.

```bash
tar: HG006_vcfs/*.vcf: Cannot stat: No such file or directory
```

This change makes the VCF tarball an optional output, and only creates it if VCFs have been created.