### PR TITLE
fix stats file typo

### DIFF
--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -172,7 +172,7 @@ workflow humanwgs_family {
   Map[String, Array[String]] stats = {
     'sample_id': sample_id,
     'num_reads': upstream.stat_num_reads,
-    'read_length_min': upstream.stat_read_length_mean,
+    'read_length_mean': upstream.stat_read_length_mean,
     'read_length_median': upstream.stat_read_length_median,
     'read_quality_mean': upstream.stat_read_quality_mean,
     'read_quality_median': upstream.stat_read_quality_median,

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -146,7 +146,7 @@ workflow humanwgs_singleton {
   Map[String, Array[String]] stats = {
     'sample_id': [sample_id],
     'num_reads': [upstream.stat_num_reads],
-    'read_length_min': [upstream.stat_read_length_mean],
+    'read_length_mean': [upstream.stat_read_length_mean],
     'read_length_median': [upstream.stat_read_length_median],
     'read_quality_mean': [upstream.stat_read_quality_mean],
     'read_quality_median': [upstream.stat_read_quality_median],


### PR DESCRIPTION
This pull request includes changes to fix typo in the `humanwgs_family` and `humanwgs_singleton` workflows.

Changes:

* [`workflows/family.wdl`](diffhunk://#diff-100e9434aeb81d7cba288a9151d468da2d50438dcf92924b12ba4b5f3bbf05bbL175-R175): Corrected the statistical key from `read_length_min` to `read_length_mean` in the `stats` map.
* [`workflows/singleton.wdl`](diffhunk://#diff-d66f13d2d26c668befcdb8ee11babff11b27e1f29bbffda10c4b92258586a5a6L149-R149): Corrected the statistical key from `read_length_min` to `read_length_mean` in the `stats` map.