### PR TITLE
Updated to TRGT v1.4.1.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1678,7 +1678,7 @@
       "tasks": {
         "trgt": {
           "key": "trgt",
-          "digest": "rpcfzfr5reqxv7jbtfncu6etivzxvgs2",
+          "digest": "6i7troewkutvnmy6oft2vkgeltp2jh3z",
           "tests": [
             {
               "inputs": {
@@ -1767,7 +1767,7 @@
         },
         "trgt_merge": {
           "key": "trgt_merge",
-          "digest": "cmdcqkqrcfpn2eoczxfwhs6zqhalzdtt",
+          "digest": "ljvpgmkt7sfdwpm64dqllrphd23ols56",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1678,7 +1678,7 @@
       "tasks": {
         "trgt": {
           "key": "trgt",
-          "digest": "6i7troewkutvnmy6oft2vkgeltp2jh3z",
+          "digest": "37d5grkookrgta6rwpmlrce3zkjavpmy",
           "tests": [
             {
               "inputs": {


### PR DESCRIPTION
- updated trgt version
- changed trgt `samtools sort` to use 8 threads to address OOM
- changed coverage_dropouts to use pb_wdl_base

- created new dockerfile: https://github.com/PacificBiosciences/wdl-dockerfiles/pull/71
- updated wdl-common: https://github.com/PacificBiosciences/wdl-common/pull/43
- pushed wiki branch feature/trgt-v1.4.1