### PR TITLE
Added sawfish.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -535,11 +535,11 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "35gn2cqouobao6vacrqbi67zhkh6nmyn",
+          "digest": "foqixa2ryrx7e64ymqylurlfad7gpdpi",
           "tests": [
             {
               "inputs": {
-                "vcf": "${resources_file_path}/sv_stats/HG002.GRCh38.pbsv.phased.vcf.gz",
+                "vcf": "${resources_file_path}/sawfish_call/output/HG002/HG002.GRCh38.structural_variants.vcf.gz",
                 "runtime_attributes": "${default_runtime_attributes}"
               },
               "output_tests": {
@@ -550,13 +550,13 @@
                   ]
                 },
                 "stat_sv_DEL_count": {
-                  "value": "19",
+                  "value": "17",
                   "test_tasks": [
                     "compare_string"
                   ]
                 },
                 "stat_sv_INS_count": {
-                  "value": "37",
+                  "value": "46",
                   "test_tasks": [
                     "compare_string"
                   ]
@@ -568,7 +568,13 @@
                   ]
                 },
                 "stat_sv_BND_count": {
-                  "value": "0",
+                  "value": "2",
+                  "test_tasks": [
+                    "compare_string"
+                  ]
+                },
+                "stat_sv_INVBND_count": {
+                  "value": "4",
                   "test_tasks": [
                     "compare_string"
                   ]
@@ -1515,120 +1521,6 @@
         }
       }
     },
-    "workflows/wdl-common/wdl/tasks/pbsv.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/pbsv.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "pbsv_discover": {
-          "key": "pbsv_discover",
-          "digest": "mcdiubcggjbwaweaciocgrnypvqn5tnb",
-          "tests": [
-            {
-              "inputs": {
-                "aligned_bam": "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam",
-                "aligned_bam_index": "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam.bai",
-                "trf_bed": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.trf.bed",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "svsig": {
-                  "value": "${resources_file_path}/pbsv_discover/HG002.GRCh38.chr6_10000000_20000000.svsig.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_gzip",
-                    "check_empty_lines"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "pbsv_call": {
-          "key": "pbsv_call",
-          "digest": "2rhytrhz52jofq7lv42akixzl55wa3lk",
-          "tests": [
-            {
-              "inputs": {
-                "sample_id": "HG002",
-                "svsigs": [
-                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.svsig.gz"
-                ],
-                "ref_fasta": "${ref_fasta}",
-                "ref_index": "${ref_index}",
-                "ref_name": "${ref_name}",
-                "shard_index": 5,
-                "regions": [
-                  "chr6"
-                ],
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "vcf": {
-                  "value": "${resources_file_path}/pbsv_call/singleton/HG002.GRCh38.5.pbsv.vcf.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            },
-            {
-              "inputs": {
-                "sample_id": "HG002",
-                "svsigs": [
-                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.svsig.gz"
-                ],
-                "ref_fasta": "${ref_fasta}",
-                "ref_index": "${ref_index}",
-                "ref_name": "${ref_name}",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "vcf": {
-                  "value": "${resources_file_path}/pbsv_call/singleton_no_shard/HG002.GRCh38.pbsv.vcf.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            },
-            {
-              "inputs": {
-                "sample_id": "HG002-trio",
-                "svsigs": [
-                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.svsig.gz",
-                  "${resources_file_path}/inputs/HG003.GRCh38.chr6_10000000_20000000.svsig.gz",
-                  "${resources_file_path}/inputs/HG004.GRCh38.chr6_10000000_20000000.svsig.gz"
-                ],
-                "sample_count": 3,
-                "ref_fasta": "${ref_fasta}",
-                "ref_index": "${ref_index}",
-                "ref_name": "${ref_name}",
-                "shard_index": 5,
-                "regions": [
-                  "chr6"
-                ],
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "vcf": {
-                  "value": "${resources_file_path}/pbsv_call/trio/HG002-trio.GRCh38.5.pbsv.vcf.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
     "workflows/wdl-common/wdl/tasks/samtools.wdl": {
       "key": "workflows/wdl-common/wdl/tasks/samtools.wdl",
       "name": "",
@@ -2495,6 +2387,163 @@
                   "test_tasks": [
                     "compare_file_basename",
                     "check_json"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "workflows/wdl-common/wdl/tasks/sawfish.wdl": {
+      "key": "workflows/wdl-common/wdl/tasks/sawfish.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "sawfish_discover": {
+          "key": "sawfish_discover",
+          "digest": "eh67skuq3swjgkbrinqhzfxf2wfea2hp",
+          "tests": [
+            {
+              "inputs": {
+                "sex": "MALE",
+                "aligned_bam": "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam",
+                "aligned_bam_index": "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam.bai",
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "expected_male_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XY.bed",
+                "expected_female_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XX.bed",
+                "out_prefix": "HG002.GRCh38",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "discover_tar": {
+                  "value": "${resources_file_path}/sawfish_discover/output/HG002/HG002.GRCh38.tar",
+                  "test_tasks": [
+                    "compare_file_basename"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "sex": "MALE",
+                "aligned_bam": "${resources_file_path}/inputs/HG003.GRCh38.chr6_10000000_20000000.bam",
+                "aligned_bam_index": "${resources_file_path}/inputs/HG003.GRCh38.chr6_10000000_20000000.bam.bai",
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "expected_male_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XY.bed",
+                "expected_female_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XX.bed",
+                "out_prefix": "HG003.GRCh38",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "discover_tar": {
+                  "value": "${resources_file_path}/sawfish_discover/output/HG003/HG003.GRCh38.tar",
+                  "test_tasks": [
+                    "compare_file_basename"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "aligned_bam": "${resources_file_path}/inputs/HG004.GRCh38.chr6_10000000_20000000.bam",
+                "aligned_bam_index": "${resources_file_path}/inputs/HG004.GRCh38.chr6_10000000_20000000.bam.bai",
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "expected_male_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XY.bed",
+                "expected_female_bed": "${resources_file_path}/hifi-wdl-resources-v2.0.0/GRCh38/hificnv/expected_cn.hg38.XX.bed",
+                "out_prefix": "HG004.GRCh38",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "discover_tar": {
+                  "value": "${resources_file_path}/sawfish_discover/output/HG004/HG004.GRCh38.tar",
+                  "test_tasks": [
+                    "compare_file_basename"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "sawfish_call": {
+          "key": "sawfish_call",
+          "digest": "gcc2gfurgryq2ziqgyfgxc5a2k3dtkyo",
+          "tests": [
+            {
+              "inputs": {
+                "discover_tars": [
+                  "${resources_file_path}/sawfish_call/input/HG002.GRCh38.tar"
+                ],
+                "aligned_bams": [
+                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam"
+                ],
+                "aligned_bam_indices": [
+                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam.bai"
+                ],
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "ref_name": "${ref_name}",
+                "out_prefix": "HG002.GRCh38.structural_variants",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "vcf": {
+                  "value": "${resources_file_path}/sawfish_call/output/HG002/HG002.GRCh38.structural_variants.vcf.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_gzip",
+                    "vcftools_validator"
+                  ]
+                },
+                "supporting_reads": {
+                  "value": "${resources_file_path}/sawfish_call/output/HG002/HG002.GRCh38.structural_variants.supporting_reads.json.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_gzip"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "discover_tars": [
+                  "${resources_file_path}/sawfish_call/input/HG002.GRCh38.tar",
+                  "${resources_file_path}/sawfish_call/input/HG003.GRCh38.tar",
+                  "${resources_file_path}/sawfish_call/input/HG004.GRCh38.tar"
+                ],
+                "aligned_bams": [
+                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam",
+                  "${resources_file_path}/inputs/HG003.GRCh38.chr6_10000000_20000000.bam",
+                  "${resources_file_path}/inputs/HG004.GRCh38.chr6_10000000_20000000.bam"
+                ],
+                "aligned_bam_indices": [
+                  "${resources_file_path}/inputs/HG002.GRCh38.chr6_10000000_20000000.bam.bai",
+                  "${resources_file_path}/inputs/HG003.GRCh38.chr6_10000000_20000000.bam.bai",
+                  "${resources_file_path}/inputs/HG004.GRCh38.chr6_10000000_20000000.bam.bai"
+                ],
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "ref_name": "${ref_name}",
+                "out_prefix": "HG002-trio.joint.GRCh38.structural_variants",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "vcf": {
+                  "value": "${resources_file_path}/sawfish_call/output/HG002-trio/HG002-trio.joint.GRCh38.structural_variants.vcf.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_gzip",
+                    "vcftools_validator"
+                  ]
+                },
+                "supporting_reads": {
+                  "value": "${resources_file_path}/sawfish_call/output/HG002-trio/HG002-trio.joint.GRCh38.structural_variants.supporting_reads.json.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_gzip"
                   ]
                 }
               }

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -191,11 +191,12 @@ workflow downstream {
     File   indel_distribution_plot = bcftools_stats_roh_small_variants.indel_distribution_plot
 
     # sv stats
-    String stat_sv_DUP_count = sv_stats.stat_sv_DUP_count
-    String stat_sv_DEL_count = sv_stats.stat_sv_DEL_count
-    String stat_sv_INS_count = sv_stats.stat_sv_INS_count
-    String stat_sv_INV_count = sv_stats.stat_sv_INV_count
-    String stat_sv_BND_count = sv_stats.stat_sv_BND_count
+    String stat_sv_DUP_count    = sv_stats.stat_sv_DUP_count
+    String stat_sv_DEL_count    = sv_stats.stat_sv_DEL_count
+    String stat_sv_INS_count    = sv_stats.stat_sv_INS_count
+    String stat_sv_INV_count    = sv_stats.stat_sv_INV_count
+    String stat_sv_INVBND_count = sv_stats.stat_sv_INVBND_count
+    String stat_sv_BND_count    = sv_stats.stat_sv_BND_count
 
     # cpg_pileup outputs
     File?  cpg_combined_bed        = cpg_pileup.combined_bed

--- a/workflows/family.inputs.json
+++ b/workflows/family.inputs.json
@@ -22,7 +22,6 @@
   "humanwgs_family.pharmcat_min_coverage": "Int (optional, default = 10)",
   "humanwgs_family.tertiary_map_file": "File? (optional)",
   "humanwgs_family.glnexus_mem_gb": "Int? (optional)",
-  "humanwgs_family.pbsv_call_mem_gb": "Int? (optional)",
   "humanwgs_family.gpu": "Boolean (optional, default = false)",
   "humanwgs_family.backend": "String",
   "humanwgs_family.zones": "String? (optional)",

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -45,9 +45,6 @@ workflow humanwgs_family {
     glnexus_mem_gb: {
       name: "Override GLnexus memory request (GB)"
     }
-    pbsv_call_mem_gb: {
-      name: "Override PBSV call memory request (GB)"
-    }
     gpu: {
       name: "Use GPU when possible"
     }
@@ -90,7 +87,6 @@ workflow humanwgs_family {
     File? tertiary_map_file
 
     Int? glnexus_mem_gb
-    Int? pbsv_call_mem_gb
 
     Boolean gpu = false
 
@@ -140,12 +136,13 @@ workflow humanwgs_family {
       input:
         family_id                  = family.family_id,
         sample_ids                 = sample_id,
-        gvcfs                      = upstream.small_variant_gvcf,
-        gvcf_indices               = upstream.small_variant_gvcf_index,
-        svsigs                     = flatten(upstream.svsigs),
+        gvcfs                      = upstream.small_variant_vcf,
+        gvcf_indices               = upstream.small_variant_vcf_index,
+        discover_tars              = upstream.discover_tar,
+        aligned_bams               = upstream.out_bam,
+        aligned_bam_indices        = upstream.out_bam_index,
         ref_map_file               = ref_map_file,
         glnexus_mem_gb             = glnexus_mem_gb,
-        pbsv_call_mem_gb           = pbsv_call_mem_gb,
         default_runtime_attributes = default_runtime_attributes
     }
   }
@@ -193,6 +190,7 @@ workflow humanwgs_family {
     'sv_DEL_count': downstream.stat_sv_DEL_count,
     'sv_INS_count': downstream.stat_sv_INS_count,
     'sv_INV_count': downstream.stat_sv_INV_count,
+    'sv_INVBND_count': downstream.stat_sv_INVBND_count,
     'sv_BND_count': downstream.stat_sv_BND_count,
     'cnv_DUP_count': upstream.stat_cnv_DUP_count,
     'cnv_DEL_count': upstream.stat_cnv_DEL_count,
@@ -322,11 +320,12 @@ workflow humanwgs_family {
     Array[File] phased_sv_vcf_index = downstream.phased_sv_vcf_index
 
     # sv stats
-    Array[String] stat_sv_DUP_count = downstream.stat_sv_DUP_count
-    Array[String] stat_sv_DEL_count = downstream.stat_sv_DEL_count
-    Array[String] stat_sv_INS_count = downstream.stat_sv_INS_count
-    Array[String] stat_sv_INV_count = downstream.stat_sv_INV_count
-    Array[String] stat_sv_BND_count = downstream.stat_sv_BND_count
+    Array[String] stat_sv_DUP_count    = downstream.stat_sv_DUP_count
+    Array[String] stat_sv_DEL_count    = downstream.stat_sv_DEL_count
+    Array[String] stat_sv_INS_count    = downstream.stat_sv_INS_count
+    Array[String] stat_sv_INV_count    = downstream.stat_sv_INV_count
+    Array[String] stat_sv_INVBND_count = downstream.stat_sv_INVBND_count
+    Array[String] stat_sv_BND_count    = downstream.stat_sv_BND_count
 
     # small variant outputs
     Array[File] phased_small_variant_vcf       = downstream.phased_small_variant_vcf
@@ -400,6 +399,6 @@ workflow humanwgs_family {
 
     # workflow metadata
     String workflow_name    = "humanwgs_family"
-    String workflow_version = "v2.1.1" + if defined(debug_version) then "~{"-" + debug_version}" else ""
+    String workflow_version = "v3.0.0-alpha1" + if defined(debug_version) then "~{"-" + debug_version}" else ""
   }
 }

--- a/workflows/joint/inputs.json
+++ b/workflows/joint/inputs.json
@@ -3,10 +3,11 @@
   "joint.sample_ids": "Array[String]",
   "joint.gvcfs": "Array[File]",
   "joint.gvcf_indices": "Array[File]",
-  "joint.svsigs": "Array[File]",
+  "joint.discover_tars": "Array[File]",
+  "joint.aligned_bams": "Array[File]",
+  "joint.aligned_bam_indices": "Array[File]",
   "joint.ref_map_file": "File",
   "joint.glnexus_mem_gb": "Int? (optional)",
-  "joint.pbsv_call_mem_gb": "Int? (optional)",
   "joint.default_runtime_attributes": {
     "max_retries": "Int",
     "container_registry": "String",

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -167,6 +167,7 @@ workflow humanwgs_singleton {
     'sv_DEL_count': [downstream.stat_sv_DEL_count],
     'sv_INS_count': [downstream.stat_sv_INS_count],
     'sv_INV_count': [downstream.stat_sv_INV_count],
+    'sv_INVBND_count': [downstream.stat_sv_INVBND_count],
     'sv_BND_count': [downstream.stat_sv_BND_count],
     'cnv_DUP_count': [upstream.stat_cnv_DUP_count],
     'cnv_DEL_count': [upstream.stat_cnv_DEL_count],
@@ -262,11 +263,12 @@ workflow humanwgs_singleton {
     File phased_sv_vcf_index = downstream.phased_sv_vcf_index
 
     # sv stats
-    String stat_sv_DUP_count = downstream.stat_sv_DUP_count
-    String stat_sv_DEL_count = downstream.stat_sv_DEL_count
-    String stat_sv_INS_count = downstream.stat_sv_INS_count
-    String stat_sv_INV_count = downstream.stat_sv_INV_count
-    String stat_sv_BND_count = downstream.stat_sv_BND_count
+    String stat_sv_DUP_count    = downstream.stat_sv_DUP_count
+    String stat_sv_DEL_count    = downstream.stat_sv_DEL_count
+    String stat_sv_INS_count    = downstream.stat_sv_INS_count
+    String stat_sv_INV_count    = downstream.stat_sv_INV_count
+    String stat_sv_INVBND_count = downstream.stat_sv_INVBND_count
+    String stat_sv_BND_count    = downstream.stat_sv_BND_count
 
     # small variant outputs
     File phased_small_variant_vcf       = downstream.phased_small_variant_vcf
@@ -332,6 +334,6 @@ workflow humanwgs_singleton {
 
     # workflow metadata
     String workflow_name    = "humanwgs_family"
-    String workflow_version = "v2.1.1" + if defined(debug_version) then "~{"-" + debug_version}" else ""
+    String workflow_version = "v3.0.0-alpha1" + if defined(debug_version) then "~{"-" + debug_version}" else ""
   }
 }


### PR DESCRIPTION
Added sawfish v0.12.7.
- Added `sawfish_discover` and `sawfish_call` tasks.
- `sawfish_call` optionally outputs supporting reads json (default `true`) for SVTopo
- Removed pbsv task calls from workflow and replaced with sawfish task calls.
- Added tests for sawfish tasks and removed tests for pbsv tasks.

To do:
- [ ] Update documentation.
- [ ] Integration test.