### PR TITLE
Gracefully handle low depth samples with StarPhase/PharmCAT

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2415,7 +2415,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "uknkltw6uwppbf5ttzrsifayz4pqplvi",
+          "digest": "",
           "tests": [
             {
               "inputs": {
@@ -2451,6 +2451,47 @@
                 },
                 "pharmcat_report_json": {
                   "value": "${resources_file_path}/run_pharmcat/output/HG002.pharmcat.report.json",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_json"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "preprocessed_filtered_vcf": "${resources_file_path}/run_pharmcat/input/HG002.GRCh38.subset.small_variants.preprocessed.filtered.vcf",
+                "input_tsvs": [
+                  "${resources_file_path}/run_pharmcat/input/HG002.NO_READS.pharmcat.tsv"
+                ],
+                "pharmcat_docker": "pgkb/pharmcat:2.15.4",
+                "out_prefix": "HG002.pharmcat",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "pharmcat_match_json": {
+                  "value": "${resources_file_path}/run_pharmcat/output/NO_READS/HG002.pharmcat.match.json",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_json"
+                  ]
+                },
+                "pharmcat_phenotype_json": {
+                  "value": "${resources_file_path}/run_pharmcat/output/NO_READS/HG002.pharmcat.phenotype.json",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_json"
+                  ]
+                },
+                "pharmcat_report_html": {
+                  "value": "${resources_file_path}/run_pharmcat/output/NO_READS/HG002.pharmcat.report.html",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_html"
+                  ]
+                },
+                "pharmcat_report_json": {
+                  "value": "${resources_file_path}/run_pharmcat/output/NO_READS/HG002.pharmcat.report.json",
                   "test_tasks": [
                     "compare_file_basename",
                     "check_json"

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2415,7 +2415,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "",
+          "digest": "uknkltw6uwppbf5ttzrsifayz4pqplvi",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2415,7 +2415,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "bpvbkvx6hsvzy7a3mymzjrwqvgxdrmj7",
+          "digest": "uknkltw6uwppbf5ttzrsifayz4pqplvi",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2390,7 +2390,7 @@
         },
         "filter_preprocessed_vcf": {
           "key": "filter_preprocessed_vcf",
-          "digest": "63mmofid6b46ugrq6hhmlpdc6htd767o",
+          "digest": "4jjtxpixe6gq6p3v7lnuyxhlzottg2ib",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2415,7 +2415,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "uknkltw6uwppbf5ttzrsifayz4pqplvi",
+          "digest": "nsabvlc6qz2u6y7ikis4pa4oljfanewp",
           "tests": [
             {
               "inputs": {

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -198,15 +198,15 @@ workflow downstream {
     String stat_sv_BND_count = sv_stats.stat_sv_BND_count
 
     # cpg_pileup outputs
-    File?   cpg_combined_bed        = cpg_pileup.combined_bed
-    File?   cpg_combined_bed_index  = cpg_pileup.combined_bed_index
-    File?   cpg_hap1_bed            = cpg_pileup.hap1_bed
-    File?   cpg_hap1_bed_index      = cpg_pileup.hap1_bed_index
-    File?   cpg_hap2_bed            = cpg_pileup.hap2_bed
-    File?   cpg_hap2_bed_index      = cpg_pileup.hap2_bed_index
-    File?   cpg_combined_bw         = cpg_pileup.combined_bw
-    File?   cpg_hap1_bw             = cpg_pileup.hap1_bw
-    File?   cpg_hap2_bw             = cpg_pileup.hap2_bw
+    File?  cpg_combined_bed        = cpg_pileup.combined_bed
+    File?  cpg_combined_bed_index  = cpg_pileup.combined_bed_index
+    File?  cpg_hap1_bed            = cpg_pileup.hap1_bed
+    File?  cpg_hap1_bed_index      = cpg_pileup.hap1_bed_index
+    File?  cpg_hap2_bed            = cpg_pileup.hap2_bed
+    File?  cpg_hap2_bed_index      = cpg_pileup.hap2_bed_index
+    File?  cpg_combined_bw         = cpg_pileup.combined_bw
+    File?  cpg_hap1_bw             = cpg_pileup.hap1_bw
+    File?  cpg_hap2_bw             = cpg_pileup.hap2_bw
     String stat_hap1_cpg_count     = cpg_pileup.stat_hap1_cpg_count
     String stat_hap2_cpg_count     = cpg_pileup.stat_hap2_cpg_count
     String stat_combined_cpg_count = cpg_pileup.stat_combined_cpg_count
@@ -215,9 +215,9 @@ workflow downstream {
     File pbstarphase_json = pbstarphase_diplotype.out_json
 
     # pharmcat and pangu outputs
-    File  pharmcat_match_json                = pharmcat.pharmcat_match_json
-    File  pharmcat_phenotype_json            = pharmcat.pharmcat_phenotype_json
-    File  pharmcat_report_html               = pharmcat.pharmcat_report_html
-    File  pharmcat_report_json               = pharmcat.pharmcat_report_json
+    File? pharmcat_match_json     = pharmcat.pharmcat_match_json
+    File? pharmcat_phenotype_json = pharmcat.pharmcat_phenotype_json
+    File? pharmcat_report_html    = pharmcat.pharmcat_report_html
+    File? pharmcat_report_json    = pharmcat.pharmcat_report_json
   }
 }

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -271,9 +271,9 @@ workflow humanwgs_family {
     File stats_file          = consolidate_stats.output_tsv
 
     # bam stats
-    Array[File] bam_stats                  = upstream.read_length_and_quality
-    Array[File] read_length_plot           = upstream.read_length_plot
-    Array[File?] read_quality_plot         = upstream.read_quality_plot
+    Array[File]   bam_stats                = upstream.read_length_and_quality
+    Array[File]   read_length_plot         = upstream.read_length_plot
+    Array[File?]  read_quality_plot        = upstream.read_quality_plot
     Array[String] stat_num_reads           = upstream.stat_num_reads
     Array[String] stat_read_length_mean    = upstream.stat_read_length_mean
     Array[String] stat_read_length_median  = upstream.stat_read_length_median
@@ -281,38 +281,38 @@ workflow humanwgs_family {
     Array[String] stat_read_quality_median = upstream.stat_read_quality_median
 
     # merged, haplotagged alignments
-    Array[File] merged_haplotagged_bam        = downstream.merged_haplotagged_bam
-    Array[File] merged_haplotagged_bam_index  = downstream.merged_haplotagged_bam_index
-    Array[String] stat_mapped_read_count      = downstream.stat_mapped_read_count
-    Array[String] stat_mapped_percent         = downstream.stat_mapped_percent
-    Array[File] mapq_distribution_plot        = downstream.mapq_distribution_plot
-    Array[File] mg_distribution_plot          = downstream.mg_distribution_plot
+    Array[File]   merged_haplotagged_bam       = downstream.merged_haplotagged_bam
+    Array[File]   merged_haplotagged_bam_index = downstream.merged_haplotagged_bam_index
+    Array[String] stat_mapped_read_count       = downstream.stat_mapped_read_count
+    Array[String] stat_mapped_percent          = downstream.stat_mapped_percent
+    Array[File]   mapq_distribution_plot       = downstream.mapq_distribution_plot
+    Array[File]   mg_distribution_plot         = downstream.mg_distribution_plot
 
     # mosdepth outputs
-    Array[File] mosdepth_summary                 = upstream.mosdepth_summary
-    Array[File] mosdepth_region_bed              = upstream.mosdepth_region_bed
-    Array[File] mosdepth_region_bed_index        = upstream.mosdepth_region_bed_index
-    Array[File] mosdepth_depth_distribution_plot = upstream.mosdepth_depth_distribution_plot
-    Array[String] stat_mean_depth                = upstream.stat_mean_depth
-    Array[String] inferred_sex                   = upstream.inferred_sex
+    Array[File]   mosdepth_summary                 = upstream.mosdepth_summary
+    Array[File]   mosdepth_region_bed              = upstream.mosdepth_region_bed
+    Array[File]   mosdepth_region_bed_index        = upstream.mosdepth_region_bed_index
+    Array[File]   mosdepth_depth_distribution_plot = upstream.mosdepth_depth_distribution_plot
+    Array[String] stat_mean_depth                  = upstream.stat_mean_depth
+    Array[String] inferred_sex                     = upstream.inferred_sex
 
     # phasing stats
-    Array[File] phase_stats             = downstream.phase_stats
-    Array[File] phase_blocks            = downstream.phase_blocks
-    Array[File] phase_haplotags         = downstream.phase_haplotags
+    Array[File]   phase_stats           = downstream.phase_stats
+    Array[File]   phase_blocks          = downstream.phase_blocks
+    Array[File]   phase_haplotags       = downstream.phase_haplotags
     Array[String] stat_phased_basepairs = downstream.stat_phased_basepairs
     Array[String] stat_phase_block_ng50 = downstream.stat_phase_block_ng50
 
     # cpg_pileup outputs
-    Array[File?] cpg_combined_bed          = downstream.cpg_combined_bed
-    Array[File?] cpg_combined_bed_index    = downstream.cpg_combined_bed_index
-    Array[File?] cpg_hap1_bed              = downstream.cpg_hap1_bed
-    Array[File?] cpg_hap1_bed_index        = downstream.cpg_hap1_bed_index
-    Array[File?] cpg_hap2_bed              = downstream.cpg_hap2_bed
-    Array[File?] cpg_hap2_bed_index        = downstream.cpg_hap2_bed_index
-    Array[File?] cpg_combined_bw           = downstream.cpg_combined_bw
-    Array[File?] cpg_hap1_bw               = downstream.cpg_hap1_bw
-    Array[File?] cpg_hap2_bw               = downstream.cpg_hap2_bw
+    Array[File?]  cpg_combined_bed        = downstream.cpg_combined_bed
+    Array[File?]  cpg_combined_bed_index  = downstream.cpg_combined_bed_index
+    Array[File?]  cpg_hap1_bed            = downstream.cpg_hap1_bed
+    Array[File?]  cpg_hap1_bed_index      = downstream.cpg_hap1_bed_index
+    Array[File?]  cpg_hap2_bed            = downstream.cpg_hap2_bed
+    Array[File?]  cpg_hap2_bed_index      = downstream.cpg_hap2_bed_index
+    Array[File?]  cpg_combined_bw         = downstream.cpg_combined_bw
+    Array[File?]  cpg_hap1_bw             = downstream.cpg_hap1_bw
+    Array[File?]  cpg_hap2_bw             = downstream.cpg_hap2_bw
     Array[String] stat_cpg_hap1_count     = downstream.stat_hap1_cpg_count
     Array[String] stat_cpg_hap2_count     = downstream.stat_hap2_cpg_count
     Array[String] stat_cpg_combined_count = downstream.stat_combined_cpg_count
@@ -335,48 +335,48 @@ workflow humanwgs_family {
     Array[File] small_variant_gvcf_index       = upstream.small_variant_gvcf_index
 
     # small variant stats
-    Array[File] small_variant_stats               = downstream.small_variant_stats
-    Array[File] bcftools_roh_out                  = downstream.bcftools_roh_out
-    Array[File] bcftools_roh_bed                  = downstream.bcftools_roh_bed
+    Array[File]   small_variant_stats             = downstream.small_variant_stats
+    Array[File]   bcftools_roh_out                = downstream.bcftools_roh_out
+    Array[File]   bcftools_roh_bed                = downstream.bcftools_roh_bed
     Array[String] stat_small_variant_SNV_count    = downstream.stat_SNV_count
     Array[String] stat_small_variant_INDEL_count  = downstream.stat_INDEL_count
     Array[String] stat_small_variant_TSTV_ratio   = downstream.stat_TSTV_ratio
     Array[String] stat_small_variant_HETHOM_ratio = downstream.stat_HETHOM_ratio
-    Array[File] snv_distribution_plot             = downstream.snv_distribution_plot
-    Array[File] indel_distribution_plot           = downstream.indel_distribution_plot
+    Array[File]   snv_distribution_plot           = downstream.snv_distribution_plot
+    Array[File]   indel_distribution_plot         = downstream.indel_distribution_plot
 
     # trgt outputs
-    Array[File] phased_trgt_vcf             = downstream.phased_trgt_vcf
-    Array[File] phased_trgt_vcf_index       = downstream.phased_trgt_vcf_index
-    Array[File] trgt_spanning_reads         = upstream.trgt_spanning_reads
-    Array[File] trgt_spanning_reads_index   = upstream.trgt_spanning_reads_index
-    Array[File] trgt_coverage_dropouts      = upstream.trgt_coverage_dropouts
+    Array[File]   phased_trgt_vcf           = downstream.phased_trgt_vcf
+    Array[File]   phased_trgt_vcf_index     = downstream.phased_trgt_vcf_index
+    Array[File]   trgt_spanning_reads       = upstream.trgt_spanning_reads
+    Array[File]   trgt_spanning_reads_index = upstream.trgt_spanning_reads_index
+    Array[File]   trgt_coverage_dropouts    = upstream.trgt_coverage_dropouts
     Array[String] stat_trgt_genotyped_count = upstream.stat_trgt_genotyped_count
     Array[String] stat_trgt_uncalled_count  = upstream.stat_trgt_uncalled_count
 
     # paraphase outputs
-    Array[File] paraphase_output_json         = upstream.paraphase_output_json
-    Array[File] paraphase_realigned_bam       = upstream.paraphase_realigned_bam
-    Array[File] paraphase_realigned_bam_index = upstream.paraphase_realigned_bam_index
-    Array[File?] paraphase_vcfs               = upstream.paraphase_vcfs
+    Array[File]  paraphase_output_json         = upstream.paraphase_output_json
+    Array[File]  paraphase_realigned_bam       = upstream.paraphase_realigned_bam
+    Array[File]  paraphase_realigned_bam_index = upstream.paraphase_realigned_bam_index
+    Array[File?] paraphase_vcfs                = upstream.paraphase_vcfs
 
     # per sample cnv outputs
-    Array[File] cnv_vcf              = upstream.cnv_vcf
-    Array[File] cnv_vcf_index        = upstream.cnv_vcf_index
-    Array[File] cnv_copynum_bedgraph = upstream.cnv_copynum_bedgraph
-    Array[File] cnv_depth_bw         = upstream.cnv_depth_bw
-    Array[File] cnv_maf_bw           = upstream.cnv_maf_bw
-    Array[String] stat_cnv_DUP_count = upstream.stat_cnv_DUP_count
-    Array[String] stat_cnv_DEL_count = upstream.stat_cnv_DEL_count
-    Array[String] stat_cnv_DUP_sum   = upstream.stat_cnv_DUP_sum
-    Array[String] stat_cnv_DEL_sum   = upstream.stat_cnv_DEL_sum
+    Array[File]   cnv_vcf              = upstream.cnv_vcf
+    Array[File]   cnv_vcf_index        = upstream.cnv_vcf_index
+    Array[File]   cnv_copynum_bedgraph = upstream.cnv_copynum_bedgraph
+    Array[File]   cnv_depth_bw         = upstream.cnv_depth_bw
+    Array[File]   cnv_maf_bw           = upstream.cnv_maf_bw
+    Array[String] stat_cnv_DUP_count   = upstream.stat_cnv_DUP_count
+    Array[String] stat_cnv_DEL_count   = upstream.stat_cnv_DEL_count
+    Array[String] stat_cnv_DUP_sum     = upstream.stat_cnv_DUP_sum
+    Array[String] stat_cnv_DEL_sum     = upstream.stat_cnv_DEL_sum
 
     # PGx outputs
-    Array[File] pbstarphase_json        = downstream.pbstarphase_json
-    Array[File] pharmcat_match_json     = downstream.pharmcat_match_json
-    Array[File] pharmcat_phenotype_json = downstream.pharmcat_phenotype_json
-    Array[File] pharmcat_report_html    = downstream.pharmcat_report_html
-    Array[File] pharmcat_report_json    = downstream.pharmcat_report_json
+    Array[File]  pbstarphase_json        = downstream.pbstarphase_json
+    Array[File?] pharmcat_match_json     = downstream.pharmcat_match_json
+    Array[File?] pharmcat_phenotype_json = downstream.pharmcat_phenotype_json
+    Array[File?] pharmcat_report_html    = downstream.pharmcat_report_html
+    Array[File?] pharmcat_report_json    = downstream.pharmcat_report_json
 
     # joint call outputs
     File? joint_small_variants_vcf       = merge_small_variant_vcfs.merged_vcf

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -244,15 +244,15 @@ workflow humanwgs_singleton {
     String stat_phase_block_ng50 = downstream.stat_phase_block_ng50
 
     # cpg_pileup outputs
-    File?   cpg_combined_bed        = downstream.cpg_combined_bed
-    File?   cpg_combined_bed_index  = downstream.cpg_combined_bed_index
-    File?   cpg_hap1_bed            = downstream.cpg_hap1_bed
-    File?   cpg_hap1_bed_index      = downstream.cpg_hap1_bed_index
-    File?   cpg_hap2_bed            = downstream.cpg_hap2_bed
-    File?   cpg_hap2_bed_index      = downstream.cpg_hap2_bed_index
-    File?   cpg_combined_bw         = downstream.cpg_combined_bw
-    File?   cpg_hap1_bw             = downstream.cpg_hap1_bw
-    File?   cpg_hap2_bw             = downstream.cpg_hap2_bw
+    File?  cpg_combined_bed        = downstream.cpg_combined_bed
+    File?  cpg_combined_bed_index  = downstream.cpg_combined_bed_index
+    File?  cpg_hap1_bed            = downstream.cpg_hap1_bed
+    File?  cpg_hap1_bed_index      = downstream.cpg_hap1_bed_index
+    File?  cpg_hap2_bed            = downstream.cpg_hap2_bed
+    File?  cpg_hap2_bed_index      = downstream.cpg_hap2_bed_index
+    File?  cpg_combined_bw         = downstream.cpg_combined_bw
+    File?  cpg_hap1_bw             = downstream.cpg_hap1_bw
+    File?  cpg_hap2_bw             = downstream.cpg_hap2_bw
     String stat_cpg_hap1_count     = downstream.stat_hap1_cpg_count
     String stat_cpg_hap2_count     = downstream.stat_hap2_cpg_count
     String stat_cpg_combined_count = downstream.stat_combined_cpg_count
@@ -312,11 +312,11 @@ workflow humanwgs_singleton {
     String stat_cnv_DEL_sum     = upstream.stat_cnv_DEL_sum
 
     # PGx outputs
-    File pbstarphase_json        = downstream.pbstarphase_json
-    File pharmcat_match_json     = downstream.pharmcat_match_json
-    File pharmcat_phenotype_json = downstream.pharmcat_phenotype_json
-    File pharmcat_report_html    = downstream.pharmcat_report_html
-    File pharmcat_report_json    = downstream.pharmcat_report_json
+    File  pbstarphase_json        = downstream.pbstarphase_json
+    File? pharmcat_match_json     = downstream.pharmcat_match_json
+    File? pharmcat_phenotype_json = downstream.pharmcat_phenotype_json
+    File? pharmcat_report_html    = downstream.pharmcat_report_html
+    File? pharmcat_report_json    = downstream.pharmcat_report_json
 
     # tertiary analysis outputs
     File? pedigree                                      = write_ped_phrank.pedigree


### PR DESCRIPTION
- Remove StarPhase outputs that are not allowed as PharmCAT input (PharmGKB/PharmCAT/issues/204)
  - `NO_READS` is used in StarPhase output to indicate no-calls.
  - `NO_MATCH` is used when StarPhase can't match the variants to a known allele.
  - This workaround removes `NO_READS`/`NO_MATCH` outputs.
- Only attempt to run PharmCAT if at least one PharmCAT region has `depth > pharmcat_min_coverage`