### PR TITLE
Update to pbmm2 v1.16.99 prerelease.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1326,7 +1326,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "jnyotwps3swl7ulnqunr5ktstoxdbvs3",
+          "digest": "lfkj5u6d6hakjxcmp3q6nzpwuz3jz5l3",
           "tests": [
             {
               "inputs": {


### PR DESCRIPTION
Release fixes behavior where `SA` tags were not stripped from aligned input.