### PR TITLE
Refactor tasks that extract stats from BAM files so that we only iterate through the BAM once.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -269,7 +269,7 @@
       "tasks": {
         "bam_stats": {
           "key": "bam_stats",
-          "digest": "",
+          "digest": "uep66lgfvrh34igqnllxgz5buvwrajha",
           "tests": [
             {
               "inputs": {
@@ -323,31 +323,45 @@
                 },
                 "stat_num_reads": {
                   "value": "27398",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_read_length_mean": {
                   "value": "14149.12",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_read_length_median": {
                   "value": "14666.5",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_read_quality_mean": {
                   "value": "35.91",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_read_quality_median": {
                   "value": "34.0",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_mapped_read_count": {
                   "value": "27398",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 },
                 "stat_mapped_percent": {
                   "value": "100.0",
-                  "test_tasks": ["compare_string"]
+                  "test_tasks": [
+                    "compare_string"
+                  ]
                 }
               }
             }
@@ -1008,7 +1022,7 @@
       "tasks": {
         "hiphase": {
           "key": "hiphase",
-          "digest": "evdi2klxze7sag3fs4p6g4h4ffqmiqzy",
+          "digest": "gmsoetfaqun5ppmdxwkrpu5z2jgnyoiq",
           "tests": [
             {
               "inputs": {
@@ -1256,7 +1270,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "4pbv52jhlacjaylj5tgqzp43a77it5xh",
+          "digest": "tr6fdqrq5p33b6zynfqgpqlua3lodnos",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -262,6 +262,99 @@
       "description": "",
       "tasks": {}
     },
+    "workflows/wdl-common/wdl/tasks/bam_stats.wdl": {
+      "key": "workflows/wdl-common/wdl/tasks/bam_stats.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "bam_stats": {
+          "key": "bam_stats",
+          "digest": "",
+          "tests": [
+            {
+              "inputs": {
+                "sample_id": "HG002",
+                "ref_name": "${ref_name}",
+                "bam": "${resources_file_path}/inputs/HG002.GRCh38.haplotagged.bam",
+                "bam_index": "${resources_file_path}/inputs/HG002.GRCh38.haplotagged.bam.bai",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "bam_statistics": {
+                  "value": "${resources_file_path}/bam_stats/output/HG002.GRCh38.bam_statistics.tsv.gz",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns",
+                    "check_gzip"
+                  ]
+                },
+                "read_length_plot": {
+                  "value": "${resources_file_path}/bam_stats/output/HG002.read_length_histogram.png",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "png_validator"
+                  ]
+                },
+                "read_quality_plot": {
+                  "value": "${resources_file_path}/bam_stats/output/HG002.read_quality_histogram.png",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "png_validator"
+                  ]
+                },
+                "mapq_distribution_plot": {
+                  "value": "${resources_file_path}/bam_stats/output/HG002.GRCh38.mapq_distribution.png",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "png_validator"
+                  ]
+                },
+                "mg_distribution_plot": {
+                  "value": "${resources_file_path}/bam_stats/output/HG002.GRCh38.mg_distribution.png",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "png_validator"
+                  ]
+                },
+                "stat_num_reads": {
+                  "value": "27398",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_read_length_mean": {
+                  "value": "14149.12",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_read_length_median": {
+                  "value": "14666.5",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_read_quality_mean": {
+                  "value": "35.91",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_read_quality_median": {
+                  "value": "34.0",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_mapped_read_count": {
+                  "value": "27398",
+                  "test_tasks": ["compare_string"]
+                },
+                "stat_mapped_percent": {
+                  "value": "100.0",
+                  "test_tasks": ["compare_string"]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "workflows/wdl-common/wdl/tasks/bcftools.wdl": {
       "key": "workflows/wdl-common/wdl/tasks/bcftools.wdl",
       "name": "",
@@ -991,250 +1084,6 @@
                     "count_columns",
                     "check_gzip"
                   ]
-                },
-                "stat_phased_basepairs": {
-                  "value": "8972304",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_phase_block_ng50": {
-                  "value": "0",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_mapped_read_count": {
-                  "value": "27398",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_mapped_percent": {
-                  "value": "100",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "mapq_distribution_plot": {
-                  "value": "${resources_file_path}/hiphase/output/HG002/HG002.GRCh38.mapq_distribution.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "mg_distribution_plot": {
-                  "value": "${resources_file_path}/hiphase/output/HG002/HG002.GRCh38.mg_distribution.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
-    "workflows/wdl-common/wdl/tasks/merge_bam_stats.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/merge_bam_stats.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "merge_bam_stats": {
-          "key": "merge_bam_stats",
-          "digest": "mjd6zpbxtabbulmq3kwhcx4cnubxaf74",
-          "tests": [
-            {
-              "inputs": {
-                "sample_id": "HG002",
-                "bam_stats": [
-                  "${resources_file_path}/pbmm2_align_wgs/sequelii_kinetics_10k/HG00133.sequelii_kinetics_10k.hifi_reads.read_length_and_quality.tsv.gz"
-                ],
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "read_length_and_quality": {
-                  "value": "${resources_file_path}/merge_bam_stats/one_input/HG002.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
-                },
-                "read_length_plot": {
-                  "value": "${resources_file_path}/merge_bam_stats/one_input/HG002.read_length_histogram.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "read_quality_plot": {
-                  "value": "${resources_file_path}/merge_bam_stats/one_input/HG002.read_quality_histogram.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "stat_num_reads": {
-                  "value": "10000",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_mean": {
-                  "value": "23508.73",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_median": {
-                  "value": "22855.5",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_mean": {
-                  "value": "26.97",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_median": {
-                  "value": "27.0",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                }
-              }
-            },
-            {
-              "inputs": {
-                "sample_id": "HG002",
-                "bam_stats": [
-                  "${resources_file_path}/pbmm2_align_wgs/sequelii_kinetics_10k/HG00133.sequelii_kinetics_10k.hifi_reads.read_length_and_quality.tsv.gz",
-                  "${resources_file_path}/pbmm2_align_wgs/vega_10k/HG002.vega_10k.hifi_reads.read_length_and_quality.tsv.gz"
-                ],
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "read_length_and_quality": {
-                  "value": "${resources_file_path}/merge_bam_stats/two_inputs/HG002.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
-                },
-                "read_length_plot": {
-                  "value": "${resources_file_path}/merge_bam_stats/two_inputs/HG002.read_length_histogram.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "read_quality_plot": {
-                  "value": "${resources_file_path}/merge_bam_stats/two_inputs/HG002.read_quality_histogram.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "stat_num_reads": {
-                  "value": "20000",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_mean": {
-                  "value": "22673.07",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_median": {
-                  "value": "22281.5",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_mean": {
-                  "value": "29.32",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_median": {
-                  "value": "29.0",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                }
-              }
-            },
-            {
-              "inputs": {
-                "sample_id": "HG002",
-                "bam_stats": [
-                  "${resources_file_path}/pbmm2_align_wgs/vega_10k_no_rq/HG002.vega_10k.no_rq.hifi_reads.read_length_and_quality.tsv.gz"
-                ],
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "read_length_and_quality": {
-                  "value": "${resources_file_path}/merge_bam_stats/no_rq/HG002.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
-                },
-                "read_length_plot": {
-                  "value": "${resources_file_path}/merge_bam_stats/no_rq/HG002.read_length_histogram.png",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "png_validator"
-                  ]
-                },
-                "stat_num_reads": {
-                  "value": "10000",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_mean": {
-                  "value": "21837.4",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_length_median": {
-                  "value": "21385.0",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_mean": {
-                  "value": "nan",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
-                },
-                "stat_read_quality_median": {
-                  "value": "nan",
-                  "test_tasks": [
-                    "compare_string"
-                  ]
                 }
               }
             }
@@ -1425,15 +1274,6 @@
                     "compare_file_basename",
                     "samtools_quickcheck"
                   ]
-                },
-                "bam_stats": {
-                  "value": "${resources_file_path}/pbmm2_align_wgs/sequelii_aligned_10k/HG00733.sequelii_aligned_10k.hifi_reads.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
                 }
               }
             },
@@ -1452,15 +1292,6 @@
                   "test_tasks": [
                     "compare_file_basename",
                     "samtools_quickcheck"
-                  ]
-                },
-                "bam_stats": {
-                  "value": "${resources_file_path}/pbmm2_align_wgs/sequelii_kinetics_10k/HG00133.sequelii_kinetics_10k.hifi_reads.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
                   ]
                 }
               }
@@ -1482,15 +1313,6 @@
                     "compare_file_basename",
                     "samtools_quickcheck"
                   ]
-                },
-                "bam_stats": {
-                  "value": "${resources_file_path}/pbmm2_align_wgs/sequelii_kinetics_10k_strip_kinetics_false/HG00133.sequelii_kinetics_10k.hifi_reads.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
                 }
               }
             },
@@ -1510,15 +1332,6 @@
                     "compare_file_basename",
                     "samtools_quickcheck"
                   ]
-                },
-                "bam_stats": {
-                  "value": "${resources_file_path}/pbmm2_align_wgs/vega_10k/HG002.vega_10k.hifi_reads.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
-                  ]
                 }
               }
             },
@@ -1537,15 +1350,6 @@
                   "test_tasks": [
                     "compare_file_basename",
                     "samtools_quickcheck"
-                  ]
-                },
-                "bam_stats": {
-                  "value": "${resources_file_path}/pbmm2_align_wgs/vega_10k_no_rq/HG002.vega_10k.no_rq.hifi_reads.read_length_and_quality.tsv.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns",
-                    "check_gzip"
                   ]
                 }
               }

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -2,6 +2,7 @@ version 1.0
 
 import "../wdl-common/wdl/structs.wdl"
 import "../wdl-common/wdl/tasks/hiphase.wdl" as Hiphase
+import "../wdl-common/wdl/tasks/bam_stats.wdl" as Bamstats
 import "../wdl-common/wdl/tasks/bcftools.wdl" as Bcftools
 import "../wdl-common/wdl/tasks/cpg_pileup.wdl" as Cpgpileup
 import "../wdl-common/wdl/tasks/pbstarphase.wdl" as Pbstarphase
@@ -101,6 +102,15 @@ workflow downstream {
   # hiphase.phased_vcfs[1] -> phased SV VCF
   # hiphase.phased_vcfs[2] -> phased TRGT VCF
 
+  call Bamstats.bam_stats {
+    input:
+      sample_id          = sample_id,
+      ref_name           = ref_map["name"],
+      bam                = hiphase.haplotagged_bam,
+      bam_index          = hiphase.haplotagged_bam_index,
+      runtime_attributes = default_runtime_attributes
+  }
+
   call Bcftools.bcftools_stats_roh_small_variants {
     input:
       sample_id          = sample_id,
@@ -171,10 +181,20 @@ workflow downstream {
     File   phase_haplotags                = hiphase.phase_haplotags
     String stat_phased_basepairs          = hiphase.stat_phased_basepairs
     String stat_phase_block_ng50          = hiphase.stat_phase_block_ng50
-    String stat_mapped_read_count         = hiphase.stat_mapped_read_count
-    String stat_mapped_percent            = hiphase.stat_mapped_percent
-    File   mapq_distribution_plot         = hiphase.mapq_distribution_plot
-    File   mg_distribution_plot           = hiphase.mg_distribution_plot
+
+    # bam stats
+    File   bam_statistics           = bam_stats.bam_statistics
+    File   read_length_plot         = bam_stats.read_length_plot
+    File?  read_quality_plot        = bam_stats.read_quality_plot
+    File   mapq_distribution_plot   = bam_stats.mapq_distribution_plot
+    File   mg_distribution_plot     = bam_stats.mg_distribution_plot
+    String stat_num_reads           = bam_stats.stat_num_reads
+    String stat_read_length_mean    = bam_stats.stat_read_length_mean
+    String stat_read_length_median  = bam_stats.stat_read_length_median
+    String stat_read_quality_mean   = bam_stats.stat_read_quality_mean
+    String stat_read_quality_median = bam_stats.stat_read_quality_median
+    String stat_mapped_read_count   = bam_stats.stat_mapped_read_count
+    String stat_mapped_percent      = bam_stats.stat_mapped_percent
 
     # small variant stats
     File   small_variant_stats     = bcftools_stats_roh_small_variants.stats

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -168,11 +168,11 @@ workflow humanwgs_family {
 
   Map[String, Array[String]] stats = {
     'sample_id': sample_id,
-    'num_reads': upstream.stat_num_reads,
-    'read_length_mean': upstream.stat_read_length_mean,
-    'read_length_median': upstream.stat_read_length_median,
-    'read_quality_mean': upstream.stat_read_quality_mean,
-    'read_quality_median': upstream.stat_read_quality_median,
+    'num_reads': downstream.stat_num_reads,
+    'read_length_mean': downstream.stat_read_length_mean,
+    'read_length_median': downstream.stat_read_length_median,
+    'read_quality_mean': downstream.stat_read_quality_mean,
+    'read_quality_median': downstream.stat_read_quality_median,
     'mapped_read_count': downstream.stat_mapped_read_count,
     'mapped_percent': downstream.stat_mapped_percent,
     'mean_depth': upstream.stat_mean_depth,
@@ -258,22 +258,22 @@ workflow humanwgs_family {
     File stats_file          = consolidate_stats.output_tsv
 
     # bam stats
-    Array[File]   bam_stats                = upstream.read_length_and_quality
-    Array[File]   read_length_plot         = upstream.read_length_plot
-    Array[File?]  read_quality_plot        = upstream.read_quality_plot
-    Array[String] stat_num_reads           = upstream.stat_num_reads
-    Array[String] stat_read_length_mean    = upstream.stat_read_length_mean
-    Array[String] stat_read_length_median  = upstream.stat_read_length_median
-    Array[String] stat_read_quality_mean   = upstream.stat_read_quality_mean
-    Array[String] stat_read_quality_median = upstream.stat_read_quality_median
+    Array[File]   bam_statistics           = downstream.bam_statistics
+    Array[File]   read_length_plot         = downstream.read_length_plot
+    Array[File?]  read_quality_plot        = downstream.read_quality_plot
+    Array[File]   mapq_distribution_plot   = downstream.mapq_distribution_plot
+    Array[File]   mg_distribution_plot     = downstream.mg_distribution_plot
+    Array[String] stat_num_reads           = downstream.stat_num_reads
+    Array[String] stat_read_length_mean    = downstream.stat_read_length_mean
+    Array[String] stat_read_length_median  = downstream.stat_read_length_median
+    Array[String] stat_read_quality_mean   = downstream.stat_read_quality_mean
+    Array[String] stat_read_quality_median = downstream.stat_read_quality_median
+    Array[String] stat_mapped_read_count   = downstream.stat_mapped_read_count
+    Array[String] stat_mapped_percent      = downstream.stat_mapped_percent
 
     # merged, haplotagged alignments
     Array[File]   merged_haplotagged_bam       = downstream.merged_haplotagged_bam
     Array[File]   merged_haplotagged_bam_index = downstream.merged_haplotagged_bam_index
-    Array[String] stat_mapped_read_count       = downstream.stat_mapped_read_count
-    Array[String] stat_mapped_percent          = downstream.stat_mapped_percent
-    Array[File]   mapq_distribution_plot       = downstream.mapq_distribution_plot
-    Array[File]   mg_distribution_plot         = downstream.mg_distribution_plot
 
     # mosdepth outputs
     Array[File]   mosdepth_summary                 = upstream.mosdepth_summary

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -125,11 +125,11 @@ workflow humanwgs_singleton {
 
   Map[String, Array[String]] stats = {
     'sample_id': [sample_id],
-    'num_reads': [upstream.stat_num_reads],
-    'read_length_mean': [upstream.stat_read_length_mean],
-    'read_length_median': [upstream.stat_read_length_median],
-    'read_quality_mean': [upstream.stat_read_quality_mean],
-    'read_quality_median': [upstream.stat_read_quality_median],
+    'num_reads': [downstream.stat_num_reads],
+    'read_length_mean': [downstream.stat_read_length_mean],
+    'read_length_median': [downstream.stat_read_length_median],
+    'read_quality_mean': [downstream.stat_read_quality_mean],
+    'read_quality_median': [downstream.stat_read_quality_median],
     'mapped_read_count': [downstream.stat_mapped_read_count],
     'mapped_percent': [downstream.stat_mapped_percent],
     'mean_depth': [upstream.stat_mean_depth],
@@ -200,22 +200,22 @@ workflow humanwgs_singleton {
     File stats_file = consolidate_stats.output_tsv
 
     # bam stats
-    File   bam_stats                = upstream.read_length_and_quality
-    File   read_length_plot         = upstream.read_length_plot
-    File?  read_quality_plot        = upstream.read_quality_plot
-    String stat_num_reads           = upstream.stat_num_reads
-    String stat_read_length_mean    = upstream.stat_read_length_mean
-    String stat_read_length_median  = upstream.stat_read_length_median
-    String stat_read_quality_mean   = upstream.stat_read_quality_mean
-    String stat_read_quality_median = upstream.stat_read_quality_median
+    File   bam_statistics           = downstream.bam_statistics
+    File   read_length_plot         = downstream.read_length_plot
+    File?  read_quality_plot        = downstream.read_quality_plot
+    File   mapq_distribution_plot   = downstream.mapq_distribution_plot
+    File   mg_distribution_plot     = downstream.mg_distribution_plot
+    String stat_num_reads           = downstream.stat_num_reads
+    String stat_read_length_mean    = downstream.stat_read_length_mean
+    String stat_read_length_median  = downstream.stat_read_length_median
+    String stat_read_quality_mean   = downstream.stat_read_quality_mean
+    String stat_read_quality_median = downstream.stat_read_quality_median
+    String stat_mapped_read_count   = downstream.stat_mapped_read_count
+    String stat_mapped_percent      = downstream.stat_mapped_percent
 
     # merged, haplotagged alignments
     File   merged_haplotagged_bam       = downstream.merged_haplotagged_bam
     File   merged_haplotagged_bam_index = downstream.merged_haplotagged_bam_index
-    String stat_mapped_read_count       = downstream.stat_mapped_read_count
-    String stat_mapped_percent          = downstream.stat_mapped_percent
-    File   mapq_distribution_plot       = downstream.mapq_distribution_plot
-    File   mg_distribution_plot         = downstream.mg_distribution_plot
 
     # mosdepth outputs
     File   mosdepth_summary                 = upstream.mosdepth_summary

--- a/workflows/upstream/upstream.wdl
+++ b/workflows/upstream/upstream.wdl
@@ -2,7 +2,6 @@ version 1.0
 
 import "../wdl-common/wdl/structs.wdl"
 import "../wdl-common/wdl/tasks/pbmm2.wdl" as Pbmm2
-import "../wdl-common/wdl/tasks/merge_bam_stats.wdl" as MergeBamStats
 import "../wdl-common/wdl/tasks/sawfish.wdl" as Sawfish
 import "../wdl-common/wdl/workflows/deepvariant/deepvariant.wdl" as DeepVariant
 import "../wdl-common/wdl/tasks/samtools.wdl" as Samtools
@@ -67,13 +66,6 @@ workflow upstream {
         ref_name           = ref_map["name"],
         runtime_attributes = default_runtime_attributes
     }
-  }
-
-  call MergeBamStats.merge_bam_stats {
-    input:
-      sample_id            = sample_id,
-      bam_stats            = pbmm2_align.bam_stats,
-      runtime_attributes   = default_runtime_attributes
   }
 
   # merge aligned bams if there are multiple
@@ -189,16 +181,6 @@ workflow upstream {
   }
 
   output {
-    # bam stats
-    File   read_length_and_quality  = merge_bam_stats.read_length_and_quality
-    File   read_length_plot         = merge_bam_stats.read_length_plot
-    File?  read_quality_plot        = merge_bam_stats.read_quality_plot
-    String stat_num_reads           = merge_bam_stats.stat_num_reads
-    String stat_read_length_mean    = merge_bam_stats.stat_read_length_mean
-    String stat_read_length_median  = merge_bam_stats.stat_read_length_median
-    String stat_read_quality_mean   = merge_bam_stats.stat_read_quality_mean
-    String stat_read_quality_median = merge_bam_stats.stat_read_quality_median
-
     # alignments
     File out_bam       = aligned_bam_data
     File out_bam_index = aligned_bam_index


### PR DESCRIPTION
- remove components from pbmm2_align task that gather stats about read length and quality
- remove task to merge per-bam stats and plot read length and quality
- remove components from hiphasse task that gather stats about mapping and alignment
- add a new bam_stats task that extracts all tasks in a single pass through the BAM and replaces the outputs from the removed components