### PR TITLE
Move coverage dropouts (v2)

### DIFF
--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -2,6 +2,7 @@ version 1.0
 
 import "../wdl-common/wdl/structs.wdl"
 import "../wdl-common/wdl/tasks/hiphase.wdl" as Hiphase
+import "../wdl-common/wdl/tasks/trgt.wdl" as Trgt
 import "../wdl-common/wdl/tasks/bcftools.wdl" as Bcftools
 import "../wdl-common/wdl/tasks/cpg_pileup.wdl" as Cpgpileup
 import "../wdl-common/wdl/tasks/pbstarphase.wdl" as Pbstarphase
@@ -105,6 +106,15 @@ workflow downstream {
   # hiphase.phased_vcfs[1] -> phased SV VCF
   # hiphase.phased_vcfs[2] -> phased TRGT VCF
 
+  call Trgt.coverage_dropouts {
+    input: 
+      aligned_bam        = hiphase.haplotagged_bam,
+      aligned_bam_index  = hiphase.haplotagged_bam_index,
+      trgt_bed           = ref_map["trgt_tandem_repeat_bed"], # !FileCoercion
+      out_prefix         = "~{sample_id}.~{ref_map['name']}",
+      runtime_attributes = default_runtime_attributes
+  }
+
   call Bcftools.bcftools_stats_roh_small_variants {
     input:
       sample_id          = sample_id,
@@ -178,6 +188,7 @@ workflow downstream {
     String stat_mapped_percent            = hiphase.stat_mapped_percent
     File   mapq_distribution_plot         = hiphase.mapq_distribution_plot
     File   mg_distribution_plot           = hiphase.mg_distribution_plot
+    File   trgt_coverage_dropouts         = coverage_dropouts.dropouts
 
     # small variant stats
     File   small_variant_stats     = bcftools_stats_roh_small_variants.stats

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -350,7 +350,7 @@ workflow humanwgs_family {
     Array[File]   phased_trgt_vcf_index     = downstream.phased_trgt_vcf_index
     Array[File]   trgt_spanning_reads       = upstream.trgt_spanning_reads
     Array[File]   trgt_spanning_reads_index = upstream.trgt_spanning_reads_index
-    Array[File]   trgt_coverage_dropouts    = upstream.trgt_coverage_dropouts
+    Array[File]   trgt_coverage_dropouts    = downstream.trgt_coverage_dropouts
     Array[String] stat_trgt_genotyped_count = upstream.stat_trgt_genotyped_count
     Array[String] stat_trgt_uncalled_count  = upstream.stat_trgt_uncalled_count
 

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -290,7 +290,7 @@ workflow humanwgs_singleton {
     File   phased_trgt_vcf_index     = downstream.phased_trgt_vcf_index
     File   trgt_spanning_reads       = upstream.trgt_spanning_reads
     File   trgt_spanning_reads_index = upstream.trgt_spanning_reads_index
-    File   trgt_coverage_dropouts    = upstream.trgt_coverage_dropouts
+    File   trgt_coverage_dropouts    = downstream.trgt_coverage_dropouts
     String stat_trgt_genotyped_count = upstream.stat_trgt_genotyped_count
     String stat_trgt_uncalled_count  = upstream.stat_trgt_uncalled_count
 

--- a/workflows/upstream/upstream.wdl
+++ b/workflows/upstream/upstream.wdl
@@ -145,15 +145,6 @@ workflow upstream {
       runtime_attributes = default_runtime_attributes
   }
 
-  call Trgt.coverage_dropouts {
-    input: 
-      aligned_bam        = aligned_bam_data,
-      aligned_bam_index  = aligned_bam_index,
-      trgt_bed           = ref_map["trgt_tandem_repeat_bed"], # !FileCoercion
-      out_prefix         = "~{sample_id}.~{ref_map['name']}",
-      runtime_attributes = default_runtime_attributes
-  }
-
   call Paraphase.paraphase {
     input:
       aligned_bam        = aligned_bam_data,
@@ -257,7 +248,6 @@ workflow upstream {
     File   trgt_vcf_index            = trgt.vcf_index
     File   trgt_spanning_reads       = trgt.bam
     File   trgt_spanning_reads_index = trgt.bam_index
-    File   trgt_coverage_dropouts    = coverage_dropouts.dropouts
     String stat_trgt_genotyped_count = trgt.stat_genotyped_count
     String stat_trgt_uncalled_count  = trgt.stat_uncalled_count
 


### PR DESCRIPTION
Moved the coverage_dropouts task from upstream.wdl to downstream.wdl, where it can take advantage of the phased reads to report haplotype dropouts.

v2 backport of #200

(cherry picked from commit 0542f795ebebc21f2115480f00ffeadf2b453138)