### PR TITLE
Add the `cpuPlatform` runtime attribute to support the workflow in GCP zones that lack n1 nodes.

### DIFF
--- a/docs/backend-gcp.md
+++ b/docs/backend-gcp.md
@@ -20,6 +20,10 @@ gcloud compute zones list | grep <region>
 
 For example, the zones in region `us-central1` are `"us-central1-a us-central1-b us-central1c us-central1f"`.
 
+#### Setting the optional cpuPlatform parameter
+
+Some GCP zones, for example `me-central1`, lack the n1 nodes used by many tasks in the workflow.  As a workaround, you can specify the minimum cpu platform to be used by the workflow to `"Intel Cascade Lake"`.  There is no need to specify the `cpuPlatform` input unless you encounter this issue.
+
 ## Running the workflow via Google's genomics Pipelines API
 
 [Cromwell's documentation](https://cromwell.readthedocs.io/en/stable/tutorials/PipelinesApi101/) on getting started with Google's genomics Pipelines API can be used as an example for how to run the workflow.

--- a/docs/family.md
+++ b/docs/family.md
@@ -82,6 +82,7 @@ flowchart TD
 | Boolean | gpu | Use GPU when possible<br/><br/>Default: `false` | [GPU support](./gpu.md#gpu-support) |
 | String | backend | Backend where the workflow will be executed<br/><br/>`["GCP", "Azure", "AWS-HealthOmics", "HPC"]` |  |
 | String? | zones | Zones where compute will take place; required if backend is set to 'AWS' or 'GCP'. | [Determining available zones in GCP](./backends.md/gcp#determining-available-zones) |
+| String? | cpuPlatform | Minimum CPU platform to use for tasks on GCP | Optional, only necessary in certain zones lacking n1 nodes. |
 | String? | gpuType | GPU type to use; required if gpu is set to `true` for cloud backends; must match backend  | [Available GPU types](./gpu.md#gpu-types) |
 | String? | container_registry | Container registry where workflow images are hosted.<br/><br/>Default: `"quay.io/pacbio"` | If omitted, [PacBio's public Quay.io registry](https://quay.io/organization/pacbio) will be used.<br/><br/>Custom container_registry must be set if backend is set to 'AWS-HealthOmics'. |
 | Boolean | preemptible | Where possible, run tasks preemptibly<br/><br/>`[true, false]`<br/><br/>Default: `true` | If set to `true`, run tasks preemptibly where possible. If set to `false`, on-demand VMs will be used for every task. Ignored if backend is set to HPC. |

--- a/docs/singleton.md
+++ b/docs/singleton.md
@@ -70,6 +70,7 @@ flowchart TD
 | Boolean | gpu | Use GPU when possible<br/><br/>Default: `false` | [GPU support](./gpu.md#gpu-support) |
 | String | backend | Backend where the workflow will be executed<br/><br/>`["GCP", "Azure", "AWS-AGC", "AWS-HealthOmics", "HPC"]` |  |
 | String? | zones | Zones where compute will take place; required if backend is set to 'AWS' or 'GCP'. | [Determining available zones in GCP](./backends/gcp.md#determining-available-zones) |
+| String? | cpuPlatform | Minimum CPU platform to use for tasks on GCP | Optional, only necessary in certain zones lacking n1 nodes. |
 | String? | gpuType | GPU type to use; required if gpu is set to `true` for cloud backends; must match backend  | [Available GPU types](./gpu.md#gpu-types) |
 | String? | container_registry | Container registry where workflow images are hosted.<br/><br/>Default: `"quay.io/pacbio"` | If omitted, [PacBio's public Quay.io registry](https://quay.io/organization/pacbio) will be used.<br/><br/>Custom container_registry must be set if backend is set to 'AWS-HealthOmics'. |
 | Boolean | preemptible | Where possible, run tasks preemptibly<br/><br/>`[true, false]`<br/><br/>Default: `true` | If set to `true`, run tasks preemptibly where possible. If set to `false`, on-demand VMs will be used for every task. Ignored if backend is set to HPC. |

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -37,7 +37,7 @@
       "tasks": {
         "slivar_small_variant": {
           "key": "slivar_small_variant",
-          "digest": "jbr45hrej5peuxvjzmqswrzop3zuqinz",
+          "digest": "irykyyoefkfuvqcoy5etbbkrrk5nkqk7",
           "tests": [
             {
               "inputs": {
@@ -142,7 +142,7 @@
         },
         "svpack_filter_annotated": {
           "key": "svpack_filter_annotated",
-          "digest": "saeebupdw3mte56psdpfwoel7qfare26",
+          "digest": "4regotmduqnudjf55e6hupo4inlxxwvr",
           "tests": [
             {
               "inputs": {
@@ -199,7 +199,7 @@
         },
         "slivar_svpack_tsv": {
           "key": "slivar_svpack_tsv",
-          "digest": "qyrthqwtbry2csopde7ot4hm7lpokqqp",
+          "digest": "hn5gts24zuaypg22monhl4kemn64eqm7",
           "tests": [
             {
               "inputs": {
@@ -269,7 +269,7 @@
       "tasks": {
         "bam_stats": {
           "key": "bam_stats",
-          "digest": "lynh3fgck5w62a7dosebmhyp35eq2cki",
+          "digest": "soaslnhsgjsqg7fx4hygtw6tg7rqoero",
           "tests": [
             {
               "inputs": {
@@ -376,7 +376,7 @@
       "tasks": {
         "bcftools_stats_roh_small_variants": {
           "key": "bcftools_stats_roh_small_variants",
-          "digest": "jjlxdrxewzw43s6sisczj7txhq55e6di",
+          "digest": "f24csdne6jhyqsbwj4pn2ny32jkqnej7",
           "tests": [
             {
               "inputs": {
@@ -525,7 +525,7 @@
         },
         "concat_pbsv_vcf": {
           "key": "concat_pbsv_vcf",
-          "digest": "pfr7cljxewp6n6pld4pl4wya3kzdy3jk",
+          "digest": "hwhxc5vukwrdcmqv2gzpvnlrfpei6vls",
           "tests": [
             {
               "inputs": {
@@ -555,7 +555,7 @@
         },
         "split_vcf_by_sample": {
           "key": "split_vcf_by_sample",
-          "digest": "dydfywxit4imoywu7rfyqyvk3wetiowk",
+          "digest": "764srio34lxmhbwy37242dh3o57tjlmg",
           "tests": [
             {
               "inputs": {
@@ -633,7 +633,7 @@
         },
         "bcftools_merge": {
           "key": "bcftools_merge",
-          "digest": "hm5g7jj2hm73dmieksaauu3ufmvtytoc",
+          "digest": "khxh6luk7sjkunxujvuvzsrvu4g4p24u",
           "tests": [
             {
               "inputs": {
@@ -717,7 +717,7 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "bru36vhjvldfcytkj2433t4naekjgctl",
+          "digest": "xygdrxwa2kxrtphi7qqlhtslgxibahxm",
           "tests": [
             {
               "inputs": {
@@ -774,7 +774,7 @@
       "tasks": {
         "cpg_pileup": {
           "key": "cpg_pileup",
-          "digest": "p36yif35pnwhh7ejpbsc2izmmye4aehs",
+          "digest": "ph425szugctndzis4ipbpr2dqr3rsnxh",
           "tests": [
             {
               "inputs": {
@@ -895,7 +895,7 @@
       "tasks": {
         "glnexus": {
           "key": "glnexus",
-          "digest": "hyyvwfb42obz4ieydkko4uef6hhc2vxl",
+          "digest": "rxlg7bfay7de7qxnmbpacbjb2lhx6sdr",
           "tests": [
             {
               "inputs": {
@@ -935,7 +935,7 @@
       "tasks": {
         "hificnv": {
           "key": "hificnv",
-          "digest": "bfpv64leadkxosmbgdg2viaugtmrmupo",
+          "digest": "7zsl7owoceakpxuondzxs2546cawp2iq",
           "tests": [
             {
               "inputs": {
@@ -1022,7 +1022,7 @@
       "tasks": {
         "hiphase": {
           "key": "hiphase",
-          "digest": "mcezwxqtvtt4hptlcegtkom322yf5jnb",
+          "digest": "vv3yil3feq4j5mwh7f3urasm2mpx6bxc",
           "tests": [
             {
               "inputs": {
@@ -1112,7 +1112,7 @@
       "tasks": {
         "mosdepth": {
           "key": "mosdepth",
-          "digest": "mwjp4365vu3k7nccm5k4rbd2ga2lqmgw",
+          "digest": "fwvxsaqxacnlh55uz4mroqtbmz527435",
           "tests": [
             {
               "inputs": {
@@ -1224,7 +1224,7 @@
       "tasks": {
         "paraphase": {
           "key": "paraphase",
-          "digest": "thdat4rkjeqlyo7fc3frju4caujej4rb",
+          "digest": "7tkmfbjxvzk3khjm5kujne7b3oookkdd",
           "tests": [
             {
               "inputs": {
@@ -1270,7 +1270,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "eupj2k52j7y4oifnqvbz2bwvu5gmwzsx",
+          "digest": "3d6qihjqn5effhdfkiymsa5gk3eyuhzi",
           "tests": [
             {
               "inputs": {
@@ -1379,7 +1379,7 @@
       "tasks": {
         "pbstarphase_diplotype": {
           "key": "pbstarphase_diplotype",
-          "digest": "vz6illqka3w4pefnou4uoryckd6cr3hu",
+          "digest": "etggero67my57jfmq7z766ql7sjldhsx",
           "tests": [
             {
               "inputs": {
@@ -1423,7 +1423,7 @@
       "tasks": {
         "samtools_merge": {
           "key": "samtools_merge",
-          "digest": "uuwtzd6saw3mxd5pbg4wvalvi4tmal7a",
+          "digest": "jzpbhgjdoi76u3urtdutj5slqvr6nzdv",
           "tests": [
             {
               "inputs": {
@@ -1465,7 +1465,7 @@
       "tasks": {
         "trgt": {
           "key": "trgt",
-          "digest": "c63pmlsvyejtse23754nll467tk3x2qn",
+          "digest": "ovkeab3xrkyn6pupayxelnnkdvs3xh7b",
           "tests": [
             {
               "inputs": {
@@ -1554,7 +1554,7 @@
         },
         "trgt_merge": {
           "key": "trgt_merge",
-          "digest": "wj3x5qdjnlsvhyo6mphy3hk6vvbbtjzk",
+          "digest": "qvnzky355rtyrky2dstbb63k56zmrmxl",
           "tests": [
             {
               "inputs": {
@@ -1588,7 +1588,7 @@
         },
         "coverage_dropouts": {
           "key": "coverage_dropouts",
-          "digest": "5ekiibz2pvpouhtkk655lei5lk2ubtzg",
+          "digest": "2jk4i4d7gssyam5ciye54nmnls6whmie",
           "tests": [
             {
               "inputs": {
@@ -1620,7 +1620,7 @@
       "tasks": {
         "split_string": {
           "key": "split_string",
-          "digest": "sia2b6zbcnw34kvg5qsyawoe4w3dvpdu",
+          "digest": "eoktvqc34mi7rprnobkiqddo74ww7vpq",
           "tests": [
             {
               "inputs": {
@@ -1644,7 +1644,7 @@
         },
         "consolidate_stats": {
           "key": "consolidate_stats",
-          "digest": "olxrzy2hoyifsvy7unp7v6t6ur5hrujv",
+          "digest": "nkztnwmascolu4z4omznmr4mlh3ulsq5",
           "tests": [
             {
               "inputs": {
@@ -1685,7 +1685,7 @@
       "tasks": {
         "write_phrank": {
           "key": "write_phrank",
-          "digest": "si2kfc6pzsrweaqed3jf5dpkpk4ysnhc",
+          "digest": "4vtt2a7yjw6taatstw4kzpi3zedntpg3",
           "tests": [
             {
               "inputs": {
@@ -1721,7 +1721,7 @@
       "tasks": {
         "deepvariant_make_examples": {
           "key": "deepvariant_make_examples",
-          "digest": "ldldviaalmgztiglsdugxauqgx6rfbrk",
+          "digest": "glvotkdvsfv3hwf5nhyjlxpcqnff6ogw",
           "tests": [
             {
               "inputs": {
@@ -1761,7 +1761,7 @@
         },
         "deepvariant_call_variants_cpu": {
           "key": "deepvariant_call_variants_cpu",
-          "digest": "3lfcmsaddhri77rtk4yecs77l7edxoc7",
+          "digest": "xnuolsti7fxpwydjj3wa3o3xquapczhu",
           "tests": [
             {
               "inputs": {
@@ -1795,7 +1795,7 @@
         },
         "deepvariant_call_variants_gpu": {
           "key": "deepvariant_call_variants_gpu",
-          "digest": "bhzsa64abtjmqd25mgknrrqu2qkwo3xe",
+          "digest": "i5amf4yh7kjlimhmspvslezhhqaxxk7m",
           "tests": [
             {
               "inputs": {
@@ -1829,7 +1829,7 @@
         },
         "deepvariant_postprocess_variants": {
           "key": "deepvariant_postprocess_variants",
-          "digest": "ih6q34f2apm6eqmyalje4cylajumvinw",
+          "digest": "4jhfmlotsneteldrwdfwvh76lk3ew7if",
           "tests": [
             {
               "inputs": {
@@ -1904,7 +1904,7 @@
       "tasks": {
         "pharmcat_preprocess": {
           "key": "pharmcat_preprocess",
-          "digest": "y7e4xvcwoiod7gakvbbimnz5ylkalmhk",
+          "digest": "ysfx7twvkvhowdeougpgs2ongzza637g",
           "tests": [
             {
               "inputs": {
@@ -1938,7 +1938,7 @@
         },
         "filter_preprocessed_vcf": {
           "key": "filter_preprocessed_vcf",
-          "digest": "qnxypqjvvofeigp4v27xpnp5dfv76duz",
+          "digest": "fknw2gott7zcmhmvchkqey4bozsywiqx",
           "tests": [
             {
               "inputs": {
@@ -1963,7 +1963,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "itfw64hpuphtqb5t6xqspch4mtscaz7f",
+          "digest": "hjmbcwuxw4epck664rte4g7qmw6ucb7t",
           "tests": [
             {
               "inputs": {
@@ -2058,7 +2058,7 @@
       "tasks": {
         "sawfish_discover": {
           "key": "sawfish_discover",
-          "digest": "fjjjgwzjez4nzzx43o67v5g6b75k3q42",
+          "digest": "uhi2t3xxyg456iuyi3an2asrle6m7leb",
           "tests": [
             {
               "inputs": {
@@ -2126,7 +2126,7 @@
         },
         "sawfish_call": {
           "key": "sawfish_call",
-          "digest": "z3l3faihcbvwpi2lkd6k4hsqmg6y552n",
+          "digest": "iuzo4gsklbebhqwol4miijpl5yhitslv",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -37,7 +37,7 @@
       "tasks": {
         "slivar_small_variant": {
           "key": "slivar_small_variant",
-          "digest": "irykyyoefkfuvqcoy5etbbkrrk5nkqk7",
+          "digest": "hk7smb3fjdzicbvjwes6oist7iwnefwm",
           "tests": [
             {
               "inputs": {
@@ -142,7 +142,7 @@
         },
         "svpack_filter_annotated": {
           "key": "svpack_filter_annotated",
-          "digest": "4regotmduqnudjf55e6hupo4inlxxwvr",
+          "digest": "dogptxnqarr6sgsxs53l4npm7mtktpdi",
           "tests": [
             {
               "inputs": {
@@ -199,7 +199,7 @@
         },
         "slivar_svpack_tsv": {
           "key": "slivar_svpack_tsv",
-          "digest": "hn5gts24zuaypg22monhl4kemn64eqm7",
+          "digest": "mo3z272srlp4old7xfa3cakvycayrfqg",
           "tests": [
             {
               "inputs": {
@@ -269,7 +269,7 @@
       "tasks": {
         "bam_stats": {
           "key": "bam_stats",
-          "digest": "soaslnhsgjsqg7fx4hygtw6tg7rqoero",
+          "digest": "wcruy2g5ce7fexnf7sctfshfcj3alw5m",
           "tests": [
             {
               "inputs": {
@@ -376,7 +376,7 @@
       "tasks": {
         "bcftools_stats_roh_small_variants": {
           "key": "bcftools_stats_roh_small_variants",
-          "digest": "f24csdne6jhyqsbwj4pn2ny32jkqnej7",
+          "digest": "a2jlnfpnjbi7gmodm5ooyo2juxbgizzo",
           "tests": [
             {
               "inputs": {
@@ -525,7 +525,7 @@
         },
         "concat_pbsv_vcf": {
           "key": "concat_pbsv_vcf",
-          "digest": "hwhxc5vukwrdcmqv2gzpvnlrfpei6vls",
+          "digest": "dufpg3hbjkz4fmb53sdbok3hulivtier",
           "tests": [
             {
               "inputs": {
@@ -555,7 +555,7 @@
         },
         "split_vcf_by_sample": {
           "key": "split_vcf_by_sample",
-          "digest": "764srio34lxmhbwy37242dh3o57tjlmg",
+          "digest": "wrmspgbtubqm4xdskkbakz6krc5iw65k",
           "tests": [
             {
               "inputs": {
@@ -633,7 +633,7 @@
         },
         "bcftools_merge": {
           "key": "bcftools_merge",
-          "digest": "khxh6luk7sjkunxujvuvzsrvu4g4p24u",
+          "digest": "jrbphhh6bnjlyqyi6dxrmp7nreelbk4g",
           "tests": [
             {
               "inputs": {
@@ -717,7 +717,7 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "xygdrxwa2kxrtphi7qqlhtslgxibahxm",
+          "digest": "i5iptmzk472kcck6varsvun7ip6pd4tf",
           "tests": [
             {
               "inputs": {
@@ -774,7 +774,7 @@
       "tasks": {
         "cpg_pileup": {
           "key": "cpg_pileup",
-          "digest": "ph425szugctndzis4ipbpr2dqr3rsnxh",
+          "digest": "iuyxupdqsyivt4ozffri4qhh6ps2ihmp",
           "tests": [
             {
               "inputs": {
@@ -895,7 +895,7 @@
       "tasks": {
         "glnexus": {
           "key": "glnexus",
-          "digest": "rxlg7bfay7de7qxnmbpacbjb2lhx6sdr",
+          "digest": "o2kth2c3iwky74yz5bfpsjymil3sbzd7",
           "tests": [
             {
               "inputs": {
@@ -935,7 +935,7 @@
       "tasks": {
         "hificnv": {
           "key": "hificnv",
-          "digest": "7zsl7owoceakpxuondzxs2546cawp2iq",
+          "digest": "tt3lk4sjqfnfpuukaghkmg6v33bnt3ic",
           "tests": [
             {
               "inputs": {
@@ -1022,7 +1022,7 @@
       "tasks": {
         "hiphase": {
           "key": "hiphase",
-          "digest": "vv3yil3feq4j5mwh7f3urasm2mpx6bxc",
+          "digest": "bi5osn4mwiklp3fre6mxcfpw5cmhjhcx",
           "tests": [
             {
               "inputs": {
@@ -1112,7 +1112,7 @@
       "tasks": {
         "mosdepth": {
           "key": "mosdepth",
-          "digest": "fwvxsaqxacnlh55uz4mroqtbmz527435",
+          "digest": "4drmk2f7kwb57hftqv6udfy5fh4eol7d",
           "tests": [
             {
               "inputs": {
@@ -1224,7 +1224,7 @@
       "tasks": {
         "paraphase": {
           "key": "paraphase",
-          "digest": "7tkmfbjxvzk3khjm5kujne7b3oookkdd",
+          "digest": "fpnnrdrj72irojbdzcrrf6ylan5ztrj3",
           "tests": [
             {
               "inputs": {
@@ -1270,7 +1270,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "3d6qihjqn5effhdfkiymsa5gk3eyuhzi",
+          "digest": "h4ehzyo7xln5zovolppsz3sk5tz3yvro",
           "tests": [
             {
               "inputs": {
@@ -1379,7 +1379,7 @@
       "tasks": {
         "pbstarphase_diplotype": {
           "key": "pbstarphase_diplotype",
-          "digest": "etggero67my57jfmq7z766ql7sjldhsx",
+          "digest": "6opgzazl7wm42vg4ftqbmvqlq3b4xsxl",
           "tests": [
             {
               "inputs": {
@@ -1423,7 +1423,7 @@
       "tasks": {
         "samtools_merge": {
           "key": "samtools_merge",
-          "digest": "jzpbhgjdoi76u3urtdutj5slqvr6nzdv",
+          "digest": "xpto234x4hmpw3uvsk3tgyc7tb2ytcaa",
           "tests": [
             {
               "inputs": {
@@ -1465,7 +1465,7 @@
       "tasks": {
         "trgt": {
           "key": "trgt",
-          "digest": "ovkeab3xrkyn6pupayxelnnkdvs3xh7b",
+          "digest": "tqgjvecbpne5cnz4ff4fhjztkpub4xtg",
           "tests": [
             {
               "inputs": {
@@ -1554,7 +1554,7 @@
         },
         "trgt_merge": {
           "key": "trgt_merge",
-          "digest": "qvnzky355rtyrky2dstbb63k56zmrmxl",
+          "digest": "dmgbkalwvudhxs6lr3xkwopq6hkwjttv",
           "tests": [
             {
               "inputs": {
@@ -1588,7 +1588,7 @@
         },
         "coverage_dropouts": {
           "key": "coverage_dropouts",
-          "digest": "2jk4i4d7gssyam5ciye54nmnls6whmie",
+          "digest": "oc5xxjmuyfnoobc6zqe5sqtfsfgkgak7",
           "tests": [
             {
               "inputs": {
@@ -1620,7 +1620,7 @@
       "tasks": {
         "split_string": {
           "key": "split_string",
-          "digest": "eoktvqc34mi7rprnobkiqddo74ww7vpq",
+          "digest": "s4v67veguw3zkfbixrfgn5foulf7kv4p",
           "tests": [
             {
               "inputs": {
@@ -1644,7 +1644,7 @@
         },
         "consolidate_stats": {
           "key": "consolidate_stats",
-          "digest": "nkztnwmascolu4z4omznmr4mlh3ulsq5",
+          "digest": "zri2goulcgcaueaezcic3po2ijgb72k4",
           "tests": [
             {
               "inputs": {
@@ -1685,7 +1685,7 @@
       "tasks": {
         "write_phrank": {
           "key": "write_phrank",
-          "digest": "4vtt2a7yjw6taatstw4kzpi3zedntpg3",
+          "digest": "qkxmuzajagtxsk3lfl4nqif6i5zmgj6f",
           "tests": [
             {
               "inputs": {
@@ -1721,7 +1721,7 @@
       "tasks": {
         "deepvariant_make_examples": {
           "key": "deepvariant_make_examples",
-          "digest": "glvotkdvsfv3hwf5nhyjlxpcqnff6ogw",
+          "digest": "zcg7prtdcfoir3lj7kvsb2mssi4gcquh",
           "tests": [
             {
               "inputs": {
@@ -1761,7 +1761,7 @@
         },
         "deepvariant_call_variants_cpu": {
           "key": "deepvariant_call_variants_cpu",
-          "digest": "xnuolsti7fxpwydjj3wa3o3xquapczhu",
+          "digest": "krunswnjbnsletxpge2egpzflynzjjyr",
           "tests": [
             {
               "inputs": {
@@ -1795,7 +1795,7 @@
         },
         "deepvariant_call_variants_gpu": {
           "key": "deepvariant_call_variants_gpu",
-          "digest": "i5amf4yh7kjlimhmspvslezhhqaxxk7m",
+          "digest": "567aoezgiryo64cbsy2c2plt3vblrbpy",
           "tests": [
             {
               "inputs": {
@@ -1829,7 +1829,7 @@
         },
         "deepvariant_postprocess_variants": {
           "key": "deepvariant_postprocess_variants",
-          "digest": "4jhfmlotsneteldrwdfwvh76lk3ew7if",
+          "digest": "bpmzthuph6iudzhtwxu2uw5myotxykva",
           "tests": [
             {
               "inputs": {
@@ -1904,7 +1904,7 @@
       "tasks": {
         "pharmcat_preprocess": {
           "key": "pharmcat_preprocess",
-          "digest": "ysfx7twvkvhowdeougpgs2ongzza637g",
+          "digest": "laipqonb5jd34wvmzmaja6rbm6ndlsn6",
           "tests": [
             {
               "inputs": {
@@ -1938,7 +1938,7 @@
         },
         "filter_preprocessed_vcf": {
           "key": "filter_preprocessed_vcf",
-          "digest": "fknw2gott7zcmhmvchkqey4bozsywiqx",
+          "digest": "juenwyp6ursmgzc7q3rjbzgqsjgstzzr",
           "tests": [
             {
               "inputs": {
@@ -1963,7 +1963,7 @@
         },
         "run_pharmcat": {
           "key": "run_pharmcat",
-          "digest": "hjmbcwuxw4epck664rte4g7qmw6ucb7t",
+          "digest": "oqllo6jjt64smy5j34odu7n7xiv5nawn",
           "tests": [
             {
               "inputs": {
@@ -2058,7 +2058,7 @@
       "tasks": {
         "sawfish_discover": {
           "key": "sawfish_discover",
-          "digest": "uhi2t3xxyg456iuyi3an2asrle6m7leb",
+          "digest": "dg2xlw6lyteu3qa544blaif6clnijkpr",
           "tests": [
             {
               "inputs": {
@@ -2126,7 +2126,7 @@
         },
         "sawfish_call": {
           "key": "sawfish_call",
-          "digest": "iuzo4gsklbebhqwol4miijpl5yhitslv",
+          "digest": "wddutc4qigu7gtk6dgzwcvsumhu6p6u5",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -2231,6 +2231,7 @@
           "preemptible_tries": 0,
           "max_retries": 0,
           "zones": "",
+          "cpuPlatform": "",
           "gpuType": "ampere",
           "container_registry": "quay.io/pacbio"
         },
@@ -2239,6 +2240,7 @@
           "preemptible_tries": 0,
           "max_retries": 0,
           "zones": "",
+          "cpuPlatform": "",
           "gpuType": "ampere",
           "container_registry": "quay.io/pacbio"
         }

--- a/workflows/downstream/inputs.json
+++ b/workflows/downstream/inputs.json
@@ -16,6 +16,7 @@
     "gpuType": "String",
     "backend": "String",
     "preemptible_tries": "Int",
-    "zones": "String"
+    "zones": "String",
+    "cpuPlatform": "String"
   }
 }

--- a/workflows/family.inputs.json
+++ b/workflows/family.inputs.json
@@ -22,6 +22,7 @@
   "humanwgs_family.gpu": "Boolean (optional, default = false)",
   "humanwgs_family.backend": "String",
   "humanwgs_family.zones": "String? (optional)",
+  "humanwgs_family.cpuPlatform": "String? (optional)",
   "humanwgs_family.gpuType": "String? (optional)",
   "humanwgs_family.container_registry": "String? (optional)",
   "humanwgs_family.container_namespace": "String? (optional)",

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -45,6 +45,9 @@ workflow humanwgs_family {
     zones: {
       name: "Zones where compute will take place; required if backend is set to 'GCP'"
     }
+    cpuPlatform: {
+      help: "Optional minimum CPU platform to use for tasks on GCP"
+    }
     gpuType: {
       name: "GPU type to use; required if gpu is set to `true` for cloud backends; must match backend"
     }
@@ -76,6 +79,7 @@ workflow humanwgs_family {
     # Backend configuration
     String backend
     String? zones
+    String? cpuPlatform
     String? gpuType
     String? container_registry
 
@@ -88,6 +92,7 @@ workflow humanwgs_family {
     input:
       backend            = backend,
       zones              = zones,
+      cpuPlatform        = cpuPlatform,
       gpuType            = gpuType,
       container_registry = container_registry
   }

--- a/workflows/joint/inputs.json
+++ b/workflows/joint/inputs.json
@@ -14,6 +14,7 @@
     "gpuType": "String",
     "backend": "String",
     "preemptible_tries": "Int",
-    "zones": "String"
+    "zones": "String",
+    "cpuPlatform": "String"
   }
 }

--- a/workflows/singleton.inputs.json
+++ b/workflows/singleton.inputs.json
@@ -11,6 +11,7 @@
   "humanwgs_singleton.gpu": "Boolean (optional, default = false)",
   "humanwgs_singleton.backend": "String",
   "humanwgs_singleton.zones": "String? (optional)",
+  "humanwgs_singleton.cpuPlatform": "String? (optional)",
   "humanwgs_singleton.gpuType": "String? (optional)",
   "humanwgs_singleton.container_registry": "String? (optional)",
   "humanwgs_singleton.container_namespace": "String? (optional)",

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -46,6 +46,9 @@ workflow humanwgs_singleton {
     zones: {
       name: "Zones where compute will take place; required if backend is set to 'GCP'"
     }
+    cpuPlatform: {
+      help: "Optional minimum CPU platform to use for tasks on GCP"
+    }
     gpuType: {
       name: "GPU type to use; required if gpu is set to `true` for cloud backends; must match backend"
     }
@@ -78,6 +81,7 @@ workflow humanwgs_singleton {
     # Backend configuration
     String backend
     String? zones
+    String? cpuPlatform
     String? gpuType
     String? container_registry
 
@@ -90,6 +94,7 @@ workflow humanwgs_singleton {
     input:
       backend            = backend,
       zones              = zones,
+      cpuPlatform        = cpuPlatform,
       gpuType            = gpuType,
       container_registry = container_registry
   }

--- a/workflows/tertiary/inputs.json
+++ b/workflows/tertiary/inputs.json
@@ -13,6 +13,7 @@
     "gpuType": "String",
     "backend": "String",
     "preemptible_tries": "Int",
-    "zones": "String"
+    "zones": "String",
+    "cpuPlatform": "String"
   }
 }

--- a/workflows/tertiary/tertiary.wdl
+++ b/workflows/tertiary/tertiary.wdl
@@ -450,7 +450,7 @@ task slivar_small_variant {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones:runtime_attributes.zones
+    zones: runtime_attributes.zones
     cpuPlatform: runtime_attributes.cpuPlatform
   }
 }
@@ -550,7 +550,7 @@ task svpack_filter_annotated {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones:runtime_attributes.zones
+    zones: runtime_attributes.zones
     cpuPlatform: runtime_attributes.cpuPlatform
   }
 }
@@ -642,7 +642,7 @@ task slivar_svpack_tsv {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones:runtime_attributes.zones
+    zones: runtime_attributes.zones
     cpuPlatform: runtime_attributes.cpuPlatform
   }
 }

--- a/workflows/tertiary/tertiary.wdl
+++ b/workflows/tertiary/tertiary.wdl
@@ -450,7 +450,8 @@ task slivar_small_variant {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones: runtime_attributes.zones
+    zones:runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpuPlatform
   }
 }
 
@@ -549,7 +550,8 @@ task svpack_filter_annotated {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones: runtime_attributes.zones
+    zones:runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpuPlatform
   }
 }
 
@@ -640,6 +642,7 @@ task slivar_svpack_tsv {
     preemptible: runtime_attributes.preemptible_tries
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
-    zones: runtime_attributes.zones
+    zones:runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpuPlatform
   }
 }

--- a/workflows/upstream/inputs.json
+++ b/workflows/upstream/inputs.json
@@ -11,6 +11,7 @@
     "gpuType": "String",
     "backend": "String",
     "preemptible_tries": "Int",
-    "zones": "String"
+    "zones": "String",
+    "cpuPlatform": "String"
   }
 }


### PR DESCRIPTION
- add cpuPlatform to every task
- add cpuPlatform to backend_configuration
- add cpuPlatform input to family and singleton entrypoints
- document input in singleton and family docs
- document input in backend-gcp doc
- update wdl-ci tests