### PR TITLE
Updates to sawfish and sv_stats.

### DIFF
--- a/docs/family.md
+++ b/docs/family.md
@@ -168,8 +168,9 @@ The `Sample` struct contains sample specific data and metadata. The struct has t
 | Array\[String\] | stat_sv_DEL_count | Structural variant DEL count | (PASS variants) |
 | Array\[String\] | stat_sv_INS_count | Structural variant INS count | (PASS variants) |
 | Array\[String\] | stat_sv_INV_count | Structural variant INV count | (PASS variants) |
-| Array\[String\] | stat_sv_INVBND_count | Structural variant INVBND count | (PASS variants) |
 | Array\[String\] | stat_sv_BND_count | Structural variant BND count | (PASS variants) |
+| Array\[String\] | stat_sv_SWAP_count | Structural variant sequence swap events | (PASS variants) |
+| File | sv_supporting_reads | Supporting reads for structural variants |  |
 | Array\[File\] | bcftools_roh_out | ROH calling |  `bcftools roh` |
 | Array\[File\] | bcftools_roh_bed | Generated from above, without filtering |  |
 | File? | joint_sv_vcf | Joint-called structural variant VCF |  |

--- a/docs/singleton.md
+++ b/docs/singleton.md
@@ -131,8 +131,9 @@ flowchart TD
 | String | stat_sv_DEL_count | Structural variant DEL count | (PASS variants) |
 | String | stat_sv_INS_count | Structural variant INS count | (PASS variants) |
 | String | stat_sv_INV_count | Structural variant INV count | (PASS variants) |
-| String | stat_sv_INVBND_count | Structural variant INVBND count | (PASS variants) |
 | String | stat_sv_BND_count | Structural variant BND count | (PASS variants) |
+| String | stat_sv_SWAP_count | Structural variant sequence swap events | (PASS variants) |
+| File | sv_supporting_reads | Supporting reads for structural variants |  |
 | File | bcftools_roh_out | ROH calling |  `bcftools roh` |
 | File | bcftools_roh_bed | Generated from above, without filtering |  |
 

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -717,7 +717,7 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "i5iptmzk472kcck6varsvun7ip6pd4tf",
+          "digest": "4qqgmft6nd55eqgtbkvmmpzikooro3fp",
           "tests": [
             {
               "inputs": {
@@ -755,8 +755,8 @@
                     "compare_string"
                   ]
                 },
-                "stat_sv_INVBND_count": {
-                  "value": "4",
+                "stat_sv_SWAP_count": {
+                  "value": "0",
                   "test_tasks": [
                     "compare_string"
                   ]
@@ -2032,7 +2032,7 @@
       "tasks": {
         "sawfish_discover": {
           "key": "sawfish_discover",
-          "digest": "wbvv3v5qtbdrgvqvtqgeeamqmhgzsw4p",
+          "digest": "fhepxt5mh25uz4eg267h6al6nclhl7vl",
           "tests": [
             {
               "inputs": {
@@ -2100,7 +2100,7 @@
         },
         "sawfish_call": {
           "key": "sawfish_call",
-          "digest": "rfuh5khjsyiajhrxz4the5j4fv3kzzhb",
+          "digest": "kjha4llh7xjs55xbkowbvfikvfnwtct4",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -717,7 +717,7 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "4qqgmft6nd55eqgtbkvmmpzikooro3fp",
+          "digest": "y36kt5y2lun65yutrgqtspgheaezbbgh",
           "tests": [
             {
               "inputs": {

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -219,12 +219,12 @@ workflow downstream {
     File   indel_distribution_plot = bcftools_stats_roh_small_variants.indel_distribution_plot
 
     # sv stats
-    String stat_sv_DUP_count    = sv_stats.stat_sv_DUP_count
-    String stat_sv_DEL_count    = sv_stats.stat_sv_DEL_count
-    String stat_sv_INS_count    = sv_stats.stat_sv_INS_count
-    String stat_sv_INV_count    = sv_stats.stat_sv_INV_count
-    String stat_sv_INVBND_count = sv_stats.stat_sv_INVBND_count
-    String stat_sv_BND_count    = sv_stats.stat_sv_BND_count
+    String stat_sv_DUP_count  = sv_stats.stat_sv_DUP_count
+    String stat_sv_DEL_count  = sv_stats.stat_sv_DEL_count
+    String stat_sv_INS_count  = sv_stats.stat_sv_INS_count
+    String stat_sv_INV_count  = sv_stats.stat_sv_INV_count
+    String stat_sv_BND_count  = sv_stats.stat_sv_BND_count
+    String stat_sv_SWAP_count = sv_stats.stat_sv_SWAP_count
 
     # cpg_pileup outputs
     File?  cpg_combined_bed        = cpg_pileup.combined_bed

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -244,7 +244,7 @@ workflow humanwgs_family {
     'sv_DEL_count': downstream.stat_sv_DEL_count,
     'sv_INS_count': downstream.stat_sv_INS_count,
     'sv_INV_count': downstream.stat_sv_INV_count,
-    'sv_INVBND_count': downstream.stat_sv_INVBND_count,
+    'sv_SWAP_count': downstream.stat_sv_SWAP_count,
     'sv_BND_count': downstream.stat_sv_BND_count,
     'cnv_DUP_count': upstream.stat_cnv_DUP_count,
     'cnv_DEL_count': upstream.stat_cnv_DEL_count,
@@ -318,14 +318,15 @@ workflow humanwgs_family {
     # sv outputs
     Array[File] phased_sv_vcf       = downstream.phased_sv_vcf
     Array[File] phased_sv_vcf_index = downstream.phased_sv_vcf_index
+    File sv_supporting_reads        = select_first([joint.sv_supporting_reads, upstream.sv_supporting_reads[0]])
 
     # sv stats
-    Array[String] stat_sv_DUP_count    = downstream.stat_sv_DUP_count
-    Array[String] stat_sv_DEL_count    = downstream.stat_sv_DEL_count
-    Array[String] stat_sv_INS_count    = downstream.stat_sv_INS_count
-    Array[String] stat_sv_INV_count    = downstream.stat_sv_INV_count
-    Array[String] stat_sv_INVBND_count = downstream.stat_sv_INVBND_count
-    Array[String] stat_sv_BND_count    = downstream.stat_sv_BND_count
+    Array[String] stat_sv_DUP_count  = downstream.stat_sv_DUP_count
+    Array[String] stat_sv_DEL_count  = downstream.stat_sv_DEL_count
+    Array[String] stat_sv_INS_count  = downstream.stat_sv_INS_count
+    Array[String] stat_sv_INV_count  = downstream.stat_sv_INV_count
+    Array[String] stat_sv_SWAP_count = downstream.stat_sv_SWAP_count
+    Array[String] stat_sv_BND_count  = downstream.stat_sv_BND_count
 
     # small variant outputs
     Array[File] phased_small_variant_vcf       = downstream.phased_small_variant_vcf

--- a/workflows/joint/joint.wdl
+++ b/workflows/joint/joint.wdl
@@ -53,6 +53,9 @@ workflow joint {
     split_joint_small_variant_vcf_indices: {
       name: "Joint-call small variant VCF indices, split by sample"
     }
+    sv_supporting_reads: {
+      name: "Supporting reads JSON"
+    }
   }
 
   input {
@@ -135,5 +138,6 @@ workflow joint {
     Array[File] split_joint_structural_variant_vcf_indices = split_sawfish.split_vcf_indices
     Array[File] split_joint_small_variant_vcfs             = split_glnexus.split_vcfs
     Array[File] split_joint_small_variant_vcf_indices      = split_glnexus.split_vcf_indices
+    File sv_supporting_reads                               = select_first([sawfish_call.supporting_reads])
   }
 }

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -188,7 +188,7 @@ workflow humanwgs_singleton {
     'sv_DEL_count': [downstream.stat_sv_DEL_count],
     'sv_INS_count': [downstream.stat_sv_INS_count],
     'sv_INV_count': [downstream.stat_sv_INV_count],
-    'sv_INVBND_count': [downstream.stat_sv_INVBND_count],
+    'sv_SWAP_count': [downstream.stat_sv_SWAP_count],
     'sv_BND_count': [downstream.stat_sv_BND_count],
     'cnv_DUP_count': [upstream.stat_cnv_DUP_count],
     'cnv_DEL_count': [upstream.stat_cnv_DEL_count],
@@ -261,14 +261,15 @@ workflow humanwgs_singleton {
     # sv outputs
     File phased_sv_vcf       = downstream.phased_sv_vcf
     File phased_sv_vcf_index = downstream.phased_sv_vcf_index
+    File sv_supporting_reads = select_first([upstream.sv_supporting_reads])
 
     # sv stats
-    String stat_sv_DUP_count    = downstream.stat_sv_DUP_count
-    String stat_sv_DEL_count    = downstream.stat_sv_DEL_count
-    String stat_sv_INS_count    = downstream.stat_sv_INS_count
-    String stat_sv_INV_count    = downstream.stat_sv_INV_count
-    String stat_sv_INVBND_count = downstream.stat_sv_INVBND_count
-    String stat_sv_BND_count    = downstream.stat_sv_BND_count
+    String stat_sv_DUP_count  = downstream.stat_sv_DUP_count
+    String stat_sv_DEL_count  = downstream.stat_sv_DEL_count
+    String stat_sv_INS_count  = downstream.stat_sv_INS_count
+    String stat_sv_INV_count  = downstream.stat_sv_INV_count
+    String stat_sv_SWAP_count = downstream.stat_sv_SWAP_count
+    String stat_sv_BND_count  = downstream.stat_sv_BND_count
 
     # small variant outputs
     File phased_small_variant_vcf       = downstream.phased_small_variant_vcf

--- a/workflows/upstream/upstream.wdl
+++ b/workflows/upstream/upstream.wdl
@@ -117,14 +117,11 @@ workflow upstream {
 
   call Sawfish.sawfish_discover {
     input:
-      sex                 = mosdepth.inferred_sex,
       aligned_bam         = aligned_bam_data,
       aligned_bam_index   = aligned_bam_index,
       ref_fasta           = ref_map["fasta"],                           # !FileCoercion
       ref_index           = ref_map["fasta_index"],                     # !FileCoercion
       out_prefix          = "~{sample_id}.~{ref_map['name']}",
-      expected_male_bed   = ref_map["hificnv_expected_bed_male"],       # !FileCoercion
-      expected_female_bed = ref_map["hificnv_expected_bed_female"],     # !FileCoercion
       runtime_attributes  = default_runtime_attributes
   }
 
@@ -199,8 +196,9 @@ workflow upstream {
     File discover_tar = sawfish_discover.discover_tar
 
     # sawfish outputs for single sample
-    File? sv_vcf       = sawfish_call.vcf
-    File? sv_vcf_index = sawfish_call.vcf_index
+    File? sv_vcf              = sawfish_call.vcf
+    File? sv_vcf_index        = sawfish_call.vcf_index
+    File? sv_supporting_reads = sawfish_call.supporting_reads
 
     # small variant outputs
     File small_variant_vcf        = deepvariant.vcf


### PR DESCRIPTION
sawfish:
- Remove `sex` and related files from inputs.
- Add `--verbose` to all filesystem command calls.
- Switch to long form arguments for all command calls, when available.
- Clean up compressed/decompressed files at the end of each task.
- Pass `supporting_reads_json` up to main workflow outputs.

sv_stats:
- Remove `InvBreakpoint` filtered event counts from output.
- Require that all counted events are `FILTER="PASS"` and `ALT` genotypes.
- Filter "sequence swap" complex variants from the INS and DEL counts, and put them in a separate `SWAP` category.  These are variants where both the `REF` and `ALT` are longer than 1bp.