### PR TITLE
fix: SV counts previously included all sites, including HOMREF.  Fix to only include ALT sites.  Expect singleton workflow counts to remain unchanged, but family workflow counts will now be (correctly) lower.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -535,7 +535,7 @@
         },
         "sv_stats": {
           "key": "sv_stats",
-          "digest": "35gn2cqouobao6vacrqbi67zhkh6nmyn",
+          "digest": "sq4w257wawiwfuuquazhhuzlhdyiiwg3",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -539,7 +539,7 @@
           "tests": [
             {
               "inputs": {
-                "vcf": "${resources_file_path}/sv_stats/HG002.GRCh38.pbsv.phased.vcf.gz",
+                "vcf": "${resources_file_path}/sv_stats/pbsv/HG002.GRCh38.pbsv.phased.vcf.gz",
                 "runtime_attributes": "${default_runtime_attributes}"
               },
               "output_tests": {


### PR DESCRIPTION
This affects only the counts in the summary stats output, not the actual VCFs.