### PR TITLE
fix: Add example_tfrecord_tars to disk_size for deepvariant_postprocess_variants.

### DIFF
--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1686,7 +1686,7 @@
         },
         "deepvariant_postprocess_variants": {
           "key": "deepvariant_postprocess_variants",
-          "digest": "bpmzthuph6iudzhtwxu2uw5myotxykva",
+          "digest": "7j2ndq2oubqpprkj3xqp7z32eszuqb44",
           "tests": [
             {
               "inputs": {


### PR DESCRIPTION
In DeepVariant >1.8, `example_tfrecord_tars` are needed by postprocess_variants.  They were added to the task, but disk_size was not increased.  We missed it in testing because it's not used by HPC or HealthOmics.

fixes #234 