### PR TITLE
feat: Use fail_reads for TRGT

### DIFF
--- a/docs/family.md
+++ b/docs/family.md
@@ -23,12 +23,23 @@
 title: family.wdl
 ---
 flowchart TD
+  subgraph "create fail_reads bait FASTA"
+    trgt_catalog["TRGT catalog BED"]
+    bait_fasta["create bait FASTA"]
+  end
   subgraph "`**Upstream of Phasing\n(per-sample)**`"
-    subgraph "per-movie"
+    subgraph "per hifi_reads uBAM"
       ubam[/"HiFi uBAM"/]
       pbmm2_align["pbmm2 align"]
     end
+    subgraph "per fail_reads uBAM"
+      fail_ubam[/"fail reads uBAM (if provided)"/]
+      bait_fail_reads["baited fail reads (if fail_reads provided)"]
+      pbmm2_align_fail_reads["pbmm2 align baited fail_reads (if fail_reads provided)"]
+      filter_fail_reads["filter fail_reads alignments (if fail_reads provided)"]
+    end
     samtools_merge["samtools merge"]
+    samtools_merge_fail_reads["samtools merge hifi_reads and fail_reads"]
     mosdepth["mosdepth"]
     paraphase["Paraphase"]
     mitorsaw["MitorSaw"]
@@ -65,12 +76,13 @@ flowchart TD
     slivar_svpack["slivar svpack tsv"]
   end
 
+  trgt_catalog --> bait_fasta --> bait_fail_reads
+  fail_ubam --> bait_fail_reads --> pbmm2_align_fail_reads --> filter_fail_reads --> samtools_merge_fail_reads
   ubam --> pbmm2_align --> samtools_merge
   samtools_merge --> mosdepth
   samtools_merge --> paraphase
   samtools_merge --> mitorsaw
-  samtools_merge --> trgt
-  samtools_merge --> trgt_dropouts
+  samtools_merge_fail_reads --> trgt
   samtools_merge --> deepvariant
   samtools_merge --> sawfish_discover
   samtools_merge --> hiphase
@@ -91,6 +103,7 @@ flowchart TD
   hiphase --> cpg_pileup
   hiphase --> starphase
   hiphase --> pharmcat
+  hiphase --> trgt_dropouts
   starphase --> pharmcat
   cpg_pileup --> methbat
 
@@ -140,6 +153,7 @@ The `Sample` struct contains sample specific data and metadata. The struct has t
 | String? | sex | Sample sex<br/>`["MALE", "FEMALE", null]` | Used by HiFiCNV and TRGT for genotyping. Allosome karyotype will default to XX unless sex is specified as `"MALE"`.  Used for tertiary analysis X-linked inheritance filtering. |
 | Boolean | affected | Affected status | If set to `true`, sample is described as being affected by all HPO terms in `phenotypes`.<br/>If set to `false`, sample is described as not being affected by all HPO terms in `phenotypes`. |
 | Array\[File\] | hifi_reads | Array of paths to HiFi reads in unaligned BAM format. |  |
+| Array\[File\]? | fail_reads | Array of paths to failed HiFi reads in unaligned BAM format (optional) | If provided, these reads will be aligned to the bait-captured regions. |
 | String? | father_id | sample_id of father (optional) |  |
 | String? | mother_id | sample_id of mother (optional) |  |
 

--- a/docs/ref_map.md
+++ b/docs/ref_map.md
@@ -5,9 +5,7 @@
 | String | name | Short name for reference | Alphanumeric characters, underscores, and dashes only.  Will be used in file names. |
 | File | fasta | Reference genome FASTA |  |
 | File | fasta_index | Reference genome FASTA index |  |
-| File | pbsv_splits | Regions for pbsv parallelization | [below](#pbsv_splits) |
-| File | pbsv_tandem_repeat_bed | Tandem Repeat BED used by PBSV to normalize SVs within TRs | [link](https://github.com/PacificBiosciences/pbsv/tree/master/annotations) |
-| File | trgt_tandem_repeat_bed | Tandem Repeat catalog (BED) for TRGT genotyping | [link](https://github.com/PacificBiosciences/trgt/blob/main/docs/repeat_files.md) |
+| File | trgt_tandem_repeat_bed | Tandem Repeat catalog (BED) for TRGT genotyping | [./trgt.md] |
 | File | sawfish_exclude_bed | Regions to be excluded for Sawfish CNV calls in gzipped BED format | [link](https://github.com/PacificBiosciences/sawfish/blob/main/docs/user_guide.md#cnv-excluded-regions) |
 | File | sawfish_exclude_bed_index | BED index | [link](https://github.com/PacificBiosciences/sawfish/blob/main/docs/user_guide.md#cnv-excluded-regions) |
 | File | sawfish_expected_bed_male | Expected allosome copy number BED for XY samples | [link](https://github.com/PacificBiosciences/sawfish/blob/main/docs/user_guide.md#expected-copy-number) |

--- a/docs/singleton.md
+++ b/docs/singleton.md
@@ -21,12 +21,23 @@
 title: singleton.wdl
 ---
 flowchart TD
+  subgraph "create fail_reads bait FASTA"
+    trgt_catalog["TRGT catalog BED"]
+    bait_fasta["create bait FASTA"]
+  end
   subgraph "`**Upstream of Phasing**`"
-    subgraph "per-movie"
+    subgraph "per hifi_reads uBAM"
       ubam[/"HiFi uBAM"/]
       pbmm2_align["pbmm2 align"]
     end
+    subgraph "per fail_reads uBAM"
+      fail_ubam[/"fail reads uBAM (if provided)"/]
+      bait_fail_reads["baited fail reads (if fail_reads provided)"]
+      pbmm2_align_fail_reads["pbmm2 align baited fail_reads (if fail_reads provided)"]
+      filter_fail_reads["filter fail_reads alignments (if fail_reads provided)"]
+    end
     samtools_merge["samtools merge"]
+    samtools_merge_fail_reads["samtools merge hifi_reads and fail_reads"]
     mosdepth["mosdepth"]
     paraphase["Paraphase"]
     mitorsaw["MitorSaw"]
@@ -53,12 +64,13 @@ flowchart TD
     slivar_svpack["slivar svpack tsv"]
   end
 
+  trgt_catalog --> bait_fasta --> bait_fail_reads
+  fail_ubam --> bait_fail_reads --> pbmm2_align_fail_reads --> filter_fail_reads --> samtools_merge_fail_reads
   ubam --> pbmm2_align --> samtools_merge
   samtools_merge --> mosdepth
   samtools_merge --> paraphase
   samtools_merge --> mitorsaw
-  samtools_merge --> trgt
-  samtools_merge --> trgt_dropouts
+  samtools_merge_fail_reads --> trgt
   samtools_merge --> deepvariant
   samtools_merge --> sawfish_discover
   samtools_merge --> hiphase
@@ -74,6 +86,7 @@ flowchart TD
   hiphase --> cpg_pileup
   hiphase --> starphase
   hiphase --> pharmcat
+  hiphase --> trgt_dropouts
   starphase --> pharmcat
   cpg_pileup --> methbat
 
@@ -89,6 +102,7 @@ flowchart TD
 | String | sample_id | Unique identifier for the sample | Alphanumeric characters, periods, dashes, and underscores are allowed. |
 | String? | sex | Sample sex<br/>`["MALE", "FEMALE"]` | Used by HiFiCNV and TRGT for genotyping. Allosome karyotype will default to XX unless sex is specified as `"MALE"`. |
 | Array\[File\] | hifi_reads | Array of paths to HiFi reads in unaligned BAM format. |  |
+| Array\[File\]? | fail_reads | Array of paths to failed HiFi reads in unaligned BAM format (optional) | If provided, these reads will be aligned to the bait-captured regions. |
 | File | [ref_map_file](./ref_map.md) | TSV containing reference genome file paths; must match backend |  |
 | String? | phenotypes | Comma-delimited list of HPO terms. | [Human Phenotype Ontology (HPO) phenotypes](https://hpo.jax.org/app/) associated with the cohort.<br/><br/>If omitted, tertiary analysis will be skipped. |
 | File? | [tertiary_map_file](./tertiary_map.md) | TSV containing tertiary analysis file paths and thresholds; must match backend | `AF`/`AC`/`nhomalt` thresholds can be modified, but this will affect performance.<br/><br/>If omitted, tertiary analysis will be skipped. |

--- a/docs/trgt.md
+++ b/docs/trgt.md
@@ -1,0 +1,13 @@
+# TRGT repeat catalogs and inclusion of `fail_reads`
+
+Our recommended TRGT Repeat Catalog is a merged set of ~70 pathogenic repeat sites ([STRchive](https://strchive.org)) and ~1M polymorphics repeats ([Adotto](https://zenodo.org/records/8329210)).  The file format is described in the [TRGT documentation](https://github.com/PacificBiosciences/trgt/blob/main/docs/repeat_files.md).
+
+For some repeat loci, you may wish to include aligned `fail_reads` in addition to aligned `hifi_reads` for TRGT genotyping.  In this workflow, we mark these loci in the repeat catalog by adding the tag `INCLUDE_FAIL_READS` in column 4, as shown in the examples below.  If you provide `fail_reads`, we will align them to the reference genome and use them _**only**_ for TRGT genotyping, _**only**_ at these loci.  By default, we do not use `fail_reads` for TRGT genotyping, and we do not use `fail_reads` for any other purpose in this workflow.
+
+Tagged loci in the default repeat catalog:
+
+```text
+chr4    39348424        39348483        ID=CANVAS_RFC1;MOTIFS=AAGGG,ACAGG,AGGGC,AAGGC,AGAGG,AAAAG,AAAGG,AAGAG,AAAGGG;STRUC=<TR>;INCLUDE_FAIL_READS
+chr9    69037270        69037304        ID=FRDA_FXN;MOTIFS=A,GAA;STRUC=<TR>;INCLUDE_FAIL_READS
+chr13   102161574       102161726       ID=SCA27B_FGF14;MOTIFS=GAA,GAAGGA,GAAGAAGAAGAAGCA,AAGGAG;STRUC=<TR>;INCLUDE_FAIL_READS
+```

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -30,6 +30,62 @@
       "description": "",
       "tasks": {}
     },
+    "workflows/process_trgt_catalog/process_trgt_catalog.wdl": {
+      "key": "workflows/process_trgt_catalog/process_trgt_catalog.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "filter_trgt_catalog": {
+          "key": "filter_trgt_catalog",
+          "digest": "iajobme7e6ssn3vqsng3lmlr4uxi7a6h",
+          "tests": [
+            {
+              "inputs": {
+                "trgt_catalog": "${datasets_file_path}/GRCh38/trgt/adotto_strchive_20250827.hg38.bed.gz",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "full_catalog": {
+                  "value": "${resources_file_path}/filter_trgt_catalog/trgt.bed",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_bed_columns",
+                    "calculate_md5sum"
+                  ]
+                },
+                "include_fail_reads_bed": {
+                  "value": "${resources_file_path}/filter_trgt_catalog/include_fail_reads.trgt.bed",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_bed_columns",
+                    "calculate_md5sum"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "trgt_catalog": "${datasets_file_path}/GRCh38/trgt/adotto_strchive_20250626.hg38.bed.gz",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "full_catalog": {
+                  "value": "${resources_file_path}/filter_trgt_catalog/trgt.bed",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_bed_columns",
+                    "calculate_md5sum"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "workflows/tertiary/tertiary.wdl": {
       "key": "workflows/tertiary/tertiary.wdl",
       "name": "",
@@ -1384,15 +1440,54 @@
             }
           ]
         },
-        "samtools_fasta": {
-          "key": "samtools_fasta",
-          "digest": "",
-          "tests": []
+        "subset_reference": {
+          "key": "subset_reference",
+          "digest": "bp5xzq323jqlo3zobarqetc76iotp3z2",
+          "tests": [
+            {
+              "inputs": {
+                "bed": "${resources_file_path}/filter_trgt_catalog/include_fail_reads.trgt.bed",
+                "ref_fasta": "${ref_fasta}",
+                "ref_index": "${ref_index}",
+                "out_prefix": "include_fail_reads",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "fasta": {
+                  "value": "${resources_file_path}/subset_reference/include_fail_reads.fasta",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "fasta_validator"
+                  ]
+                }
+              }
+            }
+          ]
         },
-        "samtools_reset": {
-          "key": "samtools_reset",
-          "digest": "",
-          "tests": []
+        "subset_bam": {
+          "key": "subset_bam",
+          "digest": "rqdqdzxpguplcszosrprsid75csl3j6f",
+          "tests": [
+            {
+              "inputs": {
+                "bed": "${resources_file_path}/filter_trgt_catalog/include_fail_reads.trgt.bed",
+                "aligned_bam": "${resources_file_path}/subset_bam/HG002.GRCh38.chr13_102100000-102200000.bam",
+                "aligned_bam_index": "${resources_file_path}/subset_bam/HG002.GRCh38.chr13_102100000-102200000.bam.bai",
+                "ref_index": "${ref_index}",
+                "out_prefix": "HG002.GRCh38.baited_fail_reads",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "bam": {
+                  "value": "${resources_file_path}/subset_bam/HG002.GRCh38.baited_fail_reads.bam",
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "samtools_quickcheck"
+                  ]
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -1403,7 +1498,7 @@
       "tasks": {
         "trgt": {
           "key": "trgt",
-          "digest": "pepbz2ll6ejtac3fg3nywigv6gf5rjym",
+          "digest": "x2lnix7cnso6qjljqx6ckhbrz3lcpimm",
           "tests": [
             {
               "inputs": {
@@ -1842,7 +1937,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "kobmohrwnpy2pzlsd7l2qvoo7ulkxth2",
+          "digest": "mx3btau4zkpnivs2m6kgg5xzyuea4aip",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1937,7 +1937,7 @@
       "tasks": {
         "pbmm2_align_wgs": {
           "key": "pbmm2_align_wgs",
-          "digest": "mx3btau4zkpnivs2m6kgg5xzyuea4aip",
+          "digest": "b27rhkpyqkpqzxsdn4uctagacoib6z7w",
           "tests": [
             {
               "inputs": {

--- a/workflows/downstream/downstream.wdl
+++ b/workflows/downstream/downstream.wdl
@@ -37,6 +37,9 @@ workflow downstream {
     trgt_vcf_index: {
       name: "TRGT VCF index"
     }
+    trgt_catalog: {
+      name: "TRGT tandem repeat catalog BED"
+    }
     aligned_bam: {
       name: "Aligned BAM"
     }
@@ -63,6 +66,7 @@ workflow downstream {
     File sv_vcf_index
     File trgt_vcf
     File trgt_vcf_index
+    File trgt_catalog
 
     File aligned_bam
     File aligned_bam_index
@@ -117,7 +121,7 @@ workflow downstream {
     input: 
       aligned_bam        = hiphase.haplotagged_bam,
       aligned_bam_index  = hiphase.haplotagged_bam_index,
-      trgt_bed           = ref_map["trgt_tandem_repeat_bed"], # !FileCoercion
+      trgt_bed           = trgt_catalog,
       out_prefix         = "~{sample_id}.~{ref_map['name']}",
       runtime_attributes = default_runtime_attributes
   }

--- a/workflows/downstream/inputs.json
+++ b/workflows/downstream/inputs.json
@@ -6,6 +6,7 @@
   "downstream.sv_vcf_index": "File",
   "downstream.trgt_vcf": "File",
   "downstream.trgt_vcf_index": "File",
+  "downstream.trgt_catalog": "File",
   "downstream.aligned_bam": "File",
   "downstream.aligned_bam_index": "File",
   "downstream.pharmcat_min_coverage": "Int",

--- a/workflows/family.inputs.json
+++ b/workflows/family.inputs.json
@@ -7,6 +7,7 @@
         "hifi_reads": [
           "File"
         ],
+        "fail_reads": "Array[File]? (optional)",
         "affected": "Boolean",
         "sex": "String? (optional); ['MALE', 'FEMALE']",
         "father_id": "String? (optional)",

--- a/workflows/humanwgs_structs.wdl
+++ b/workflows/humanwgs_structs.wdl
@@ -7,6 +7,7 @@ struct Sample {
   Boolean affected
 
   Array[File] hifi_reads
+  Array[File]? fail_reads
 
   String? father_id
   String? mother_id

--- a/workflows/process_trgt_catalog/inputs.json
+++ b/workflows/process_trgt_catalog/inputs.json
@@ -1,0 +1,14 @@
+{
+  "process_trgt_catalog.trgt_catalog": "File",
+  "process_trgt_catalog.ref_fasta": "File",
+  "process_trgt_catalog.ref_index": "File",
+  "process_trgt_catalog.default_runtime_attributes": {
+    "max_retries": "Int",
+    "container_registry": "String",
+    "gpuType": "String",
+    "backend": "String",
+    "preemptible_tries": "Int",
+    "zones": "String",
+    "cpuPlatform": "String"
+  }
+}

--- a/workflows/process_trgt_catalog/process_trgt_catalog.wdl
+++ b/workflows/process_trgt_catalog/process_trgt_catalog.wdl
@@ -1,0 +1,155 @@
+version 1.0
+
+import "../wdl-common/wdl/structs.wdl"
+import "../wdl-common/wdl/tasks/samtools.wdl" as Samtools
+
+workflow process_trgt_catalog {
+  meta {
+    description: "Process a TRGT catalog to identify regions for which to include fail_reads."
+  }
+
+  parameter_meta {
+    trgt_catalog: {
+      name: "Repeat catalog for TRGT; BED"
+    }
+    ref_fasta: {
+      name: "Reference FASTA"
+    }
+    ref_index: {
+      name: "Reference FASTA index"
+    }
+    default_runtime_attributes: {
+      name: "Default runtime attribute structure"
+    }
+    full_catalog: {
+      name: "Repeat catalog for TRGT, flags stripped; BED"
+    }
+    include_fail_reads_bed: {
+      name: "Subset of repeat catalog for which to include fail reads; BED"
+    }
+    fail_reads_bait_fasta: {
+      name: "FASTA of reference sequences for baiting fail reads; FASTA"
+    }
+    fail_reads_bait_index: {
+      name: "Index of reference sequences for baiting fail reads; FASTA index"
+    }
+    msg: {
+      name: "Array of messages"
+    }
+  }
+
+  input {
+    File trgt_catalog
+
+    File ref_fasta
+    File ref_index
+
+    RuntimeAttributes default_runtime_attributes
+  }
+
+  call filter_trgt_catalog {
+    input:
+      trgt_catalog = trgt_catalog,
+      runtime_attributes = default_runtime_attributes
+  }
+
+  if (defined(filter_trgt_catalog.include_fail_reads_bed)) {
+    call Samtools.subset_reference {
+      input:
+        bed = select_first([filter_trgt_catalog.include_fail_reads_bed]),
+        ref_fasta = ref_fasta,
+        ref_index = ref_index,
+        out_prefix = "fail_reads_subset",
+        runtime_attributes = default_runtime_attributes
+    }
+  }
+
+  output {
+    File  full_catalog           = filter_trgt_catalog.full_catalog
+    File? include_fail_reads_bed = filter_trgt_catalog.include_fail_reads_bed
+    File? fail_reads_bait_fasta  = subset_reference.fasta
+    File? fail_reads_bait_index  = subset_reference.fasta_index
+    Array[String] msg            = filter_trgt_catalog.msg
+  }
+
+}
+
+task filter_trgt_catalog {
+  meta {
+    description: "Filter and clean a TRGT catalog to identify regions for which to include fail_reads."
+  }
+
+  parameter_meta {
+    trgt_catalog: {
+      name: "Repeat catalog for TRGT; BED"
+    }
+    runtime_attributes: {
+      name: "Runtime attribute structure"
+    }
+    full_catalog: {
+      name: "Repeat catalog for TRGT, flags stripped; BED"
+    }
+    include_fail_reads_bed: {
+      name: "Subset of repeat catalog for which to include fail reads; BED"
+    }
+    msg: {
+      name: "Array of messages"
+    }
+  }
+
+  input {
+    File trgt_catalog
+
+    RuntimeAttributes runtime_attributes
+  }
+
+  Int threads   = 2
+  Int mem_gb    = 4
+  Int disk_size = ceil(size(trgt_catalog, "GB") + 20)
+
+  command <<<
+    set -eu
+
+    touch messages.txt
+
+    if gzip --test ~{trgt_catalog}; then
+      gunzip --stdout ~{trgt_catalog} > in.bed
+      bed="./in.bed"
+    else
+      bed="~{trgt_catalog}"
+    fi
+
+    # sanitize general TRGT repeat catalog to remove INCLUDE_FAIL_READS flag
+    sed 's/;INCLUDE_FAIL_READS//' ${bed} > trgt.bed
+
+    # Create a catalog with regions that have the INCLUDE_FAIL_READS flag and sanitize to remove INCLUDE_FAIL_READS flag
+    # If the flag is not present, remove the file
+    grep 'INCLUDE_FAIL_READS' ${bed} \
+    | sed 's/;INCLUDE_FAIL_READS//' \
+    > include_fail_reads.trgt.bed || true
+
+    if [ ! -s include_fail_reads.trgt.bed ]; then
+      echo "No repeats in ~{trgt_catalog} contain INCLUDE_FAIL_READS flag. fail_reads will not be used for TRGT." >> messages.txt
+      rm include_fail_reads.trgt.bed
+    fi
+  >>>
+
+  output {
+    File  full_catalog           = "trgt.bed"
+    File? include_fail_reads_bed = "include_fail_reads.trgt.bed"
+    Array[String] msg            = read_lines("messages.txt")
+  }
+
+  runtime {
+    docker: "~{runtime_attributes.container_registry}/pb_wdl_base@sha256:4b889a1f21a6a7fecf18820613cf610103966a93218de772caba126ab70a8e87"
+    cpu: threads
+    memory: mem_gb + " GiB"
+    disk: disk_size + " GB"
+    disks: "local-disk " + disk_size + " HDD"
+    preemptible: runtime_attributes.preemptible_tries
+    maxRetries: runtime_attributes.max_retries
+    awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
+    zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpuPlatform
+  }
+}

--- a/workflows/singleton.inputs.json
+++ b/workflows/singleton.inputs.json
@@ -4,6 +4,7 @@
   "humanwgs_singleton.hifi_reads": [
     "File"
   ],
+  "humanwgs_singleton.fail_reads": "Array[File]? (optional)",
   "humanwgs_singleton.phenotypes": "String? (optional)",
   "humanwgs_singleton.ref_map_file": "File",
   "humanwgs_singleton.tertiary_map_file": "File? (optional)",

--- a/workflows/upstream/inputs.json
+++ b/workflows/upstream/inputs.json
@@ -2,8 +2,13 @@
   "upstream.sample_id": "String",
   "upstream.sex": "String? (optional)",
   "upstream.hifi_reads": "Array[File]",
+  "upstream.fail_reads": "Array[File]? (optional)",
   "upstream.ref_map_file": "File",
   "upstream.max_reads_per_alignment_chunk": "Int",
+  "upstream.trgt_catalog": "File",
+  "upstream.fail_reads_bed": "File? (optional)",
+  "upstream.fail_reads_bait_fasta": "File? (optional)",
+  "upstream.fail_reads_bait_index": "File? (optional)",
   "upstream.single_sample": "Boolean (optional, default = false)",
   "upstream.gpu": "Boolean",
   "upstream.default_runtime_attributes": {

--- a/workflows/upstream/upstream.wdl
+++ b/workflows/upstream/upstream.wdl
@@ -105,7 +105,8 @@ workflow upstream {
           bam                = fail_read_bam,
           ref_fasta          = select_first([fail_reads_bait_fasta]),
           ref_index          = select_first([fail_reads_bait_index]),
-          ref_name           = ref_map["name"],
+          ref_name           = 'bait_ref',
+          keep_unmapped      = false,
           min_length         = 1000,
           runtime_attributes = default_runtime_attributes
       }
@@ -117,6 +118,7 @@ workflow upstream {
           ref_fasta          = ref_map["fasta"],            # !FileCoercion
           ref_index          = ref_map["fasta_index"],      # !FileCoercion
           ref_name           = ref_map["name"],
+          keep_unmapped      = false,
           runtime_attributes = default_runtime_attributes
       }
 
@@ -211,8 +213,8 @@ workflow upstream {
       runtime_attributes = default_runtime_attributes
   }
 
-  # if fail_reads are provided, merge them with the aligned hifi bams for trgt
-  if (defined(fail_reads)) {
+  # if fail_reads were aligned, merge them with the aligned hifi bams for trgt
+  if (defined(subset_bam.bam)) {
     call Samtools.samtools_merge as merge_hifi_fail_bams {
       input:
         bams               = flatten(select_all([flatten(pbmm2.aligned_bams), subset_bam.bam])),
@@ -222,7 +224,7 @@ workflow upstream {
   }
 
   String include_fail_reads = 
-    if (defined(fail_reads) && defined(fail_reads_bed)) 
+    if (defined(subset_bam.bam) && defined(fail_reads_bed)) 
     then "Including fail_reads for TRGT genotyping for regions specified in the TRGT catalog."
     else ""
 


### PR DESCRIPTION
- created a `trgt_tandem_repeat_bed` where we've flagged CANVAS_RFC1, FRDA_FXN, SCA27B_FGF14 with `;INCLUDE_FAIL_READS` in column 4
- new subworkflow `process_trgt_catalog.wdl` that
  - removes the `;INCLUDE_FAIL_READS` flag to produce a clean trgt catalog (in case this would interfere with trgt functions)
  - extracts records flagged with `;INCLUDE_FAIL_READS` into a `include_fail_reads_bed` file
  - uses this `include_fail_reads_bed` to create a "bait" fasta with these loci +/- 10kb
- adds a new optional `fail_reads` input for each sample
- if 1) `fail_reads` have been provided and 2) there were records flagged with `;INCLUDE_FAIL_READS`
  - align `fail_reads` to the bait fasta
  - realign baited reads to the GRCh38 reference
  - filter the GRCh38 aligned fail_reads to only include reads mapped to the flagged loci +/- 10kb
  - merge the filtered GRCh38 aligned fail_reads with the aligned hifi_reads, only to be used by `trgt genotype`
    - if, in the future, `trgt genotype` is modified to allow separate hifi_reads and fail_reads input, we can skip the extra merge step
  - modified trgt task to expose `--min-read-quality`; set to -1.0 at runtime